### PR TITLE
[bspwm] Separate focused/unfocused state from occupation state

### DIFF
--- a/README.md
+++ b/README.md
@@ -674,11 +674,17 @@ See [the bspwm module](#module-internalbspwm) for details on `label-dimmed`.
   ;   %icon%
   ;   %index%
   ; Default: %icon%  %name%
+  ; Focused workspaces may either all use the same properties...
   label-focused = %icon%
   label-focused-foreground = #ffffff
   label-focused-background = #3f3f3f
   label-focused-underline = #fba922
   label-focused-padding = 4
+  ; ... or you may change the properties depending of their state
+  label-focus-occupied = O
+  label-focused-occupied-foreground = #ffffff
+  label-focused-urgent = X
+  label-focused-urgent-foreground = #ff0000
 
   ; Available tokens:
   ;   %name%

--- a/include/drawtypes/label.hpp
+++ b/include/drawtypes/label.hpp
@@ -27,4 +27,5 @@ namespace drawtypes
 
   std::unique_ptr<Label> get_config_label(std::string module_name, std::string label_name = "label", bool required = true, std::string def = "");
   std::unique_ptr<Label> get_optional_config_label(std::string module_name, std::string label_name = "label", std::string def = "");
+  std::unique_ptr<Label> get_either_config_label(std::string config_path, std::string label_name1, std::string label_name2, std::string def);
 }

--- a/include/modules/bspwm.hpp
+++ b/include/modules/bspwm.hpp
@@ -20,10 +20,12 @@ namespace modules
     enum Flag
     {
       WORKSPACE_NONE,
-      WORKSPACE_ACTIVE,
       WORKSPACE_URGENT,
       WORKSPACE_EMPTY,
       WORKSPACE_OCCUPIED,
+      WORKSPACE_FOCUSED_URGENT,
+      WORKSPACE_FOCUSED_EMPTY,
+      WORKSPACE_FOCUSED_OCCUPIED,
       // used when the monitor is unfocused
       WORKSPACE_DIMMED,
 

--- a/include/modules/bspwm.hpp
+++ b/include/modules/bspwm.hpp
@@ -23,9 +23,11 @@ namespace modules
       WORKSPACE_URGENT,
       WORKSPACE_EMPTY,
       WORKSPACE_OCCUPIED,
+
       WORKSPACE_FOCUSED_URGENT,
       WORKSPACE_FOCUSED_EMPTY,
       WORKSPACE_FOCUSED_OCCUPIED,
+
       // used when the monitor is unfocused
       WORKSPACE_DIMMED,
 

--- a/include/utils/config.hpp
+++ b/include/utils/config.hpp
@@ -105,6 +105,19 @@ namespace config
   }
 
   /**
+   * Return true if the selected property exists
+   */
+  template<typename T>
+  bool has(std::string section, std::string key)
+  {
+    std::lock_guard<std::recursive_mutex> lck(config::mtx);
+
+    auto val = get_tree().get_optional<T>(build_path(section, key));
+    return val != boost::none;
+  }
+
+
+  /**
    * Gets the value of a variable by section and parameter name
    */
   template<typename T>

--- a/src/drawtypes/label.cpp
+++ b/src/drawtypes/label.cpp
@@ -43,4 +43,12 @@ namespace drawtypes
   std::unique_ptr<Label> get_optional_config_label(std::string config_path, std::string label_name, std::string def) {
     return get_config_label(config_path, label_name, false, def);
   }
+
+  std::unique_ptr<Label> get_either_config_label(std::string config_path, std::string label_name1, std::string label_name2, std::string def)
+  {
+    if (config::has<std::string>(config_path, label_name1))
+      return get_config_label(config_path, label_name1, true, "");
+    else
+      return get_optional_config_label(config_path, label_name2, def);
+  }
 }

--- a/src/modules/bspwm.cpp
+++ b/src/modules/bspwm.cpp
@@ -67,12 +67,16 @@ BspwmModule::BspwmModule(std::string name_, std::string monitor)
   this->formatter->add(DEFAULT_FORMAT, TAG_LABEL_STATE, { TAG_LABEL_STATE }, { TAG_LABEL_MODE });
 
   if (this->formatter->has(TAG_LABEL_STATE)) {
-    this->state_labels.insert(std::make_pair(WORKSPACE_OCCUPIED, drawtypes::get_optional_config_label(name(), "label-occupied", DEFAULT_WS_LABEL)));
+    auto label_focused = drawtypes::get_optional_config_label(name(), "label-focused", DEFAULT_WS_LABEL);
+	this->state_labels.insert(std::make_pair(WORKSPACE_OCCUPIED, drawtypes::get_optional_config_label(name(), "label-occupied", DEFAULT_WS_LABEL)));
     this->state_labels.insert(std::make_pair(WORKSPACE_URGENT, drawtypes::get_optional_config_label(name(), "label-urgent", DEFAULT_WS_LABEL)));
     this->state_labels.insert(std::make_pair(WORKSPACE_EMPTY, drawtypes::get_optional_config_label(name(), "label-empty", DEFAULT_WS_LABEL)));
-    this->state_labels.insert(std::make_pair(WORKSPACE_FOCUSED_OCCUPIED, drawtypes::get_optional_config_label(name(), "label-focused-occupied", DEFAULT_WS_LABEL)));
-    this->state_labels.insert(std::make_pair(WORKSPACE_FOCUSED_URGENT, drawtypes::get_optional_config_label(name(), "label-focused-urgent", DEFAULT_WS_LABEL)));
-    this->state_labels.insert(std::make_pair(WORKSPACE_FOCUSED_EMPTY, drawtypes::get_optional_config_label(name(), "label-focused-empty", DEFAULT_WS_LABEL)));
+    this->state_labels.insert(std::make_pair(WORKSPACE_FOCUSED_OCCUPIED,
+          drawtypes::get_either_config_label(name(), "label-focused-occupied", "label-focused", DEFAULT_WS_LABEL)));
+    this->state_labels.insert(std::make_pair(WORKSPACE_FOCUSED_URGENT,
+          drawtypes::get_either_config_label(name(), "label-focused-urgent", "label-focused", DEFAULT_WS_LABEL)));
+    this->state_labels.insert(std::make_pair(WORKSPACE_FOCUSED_EMPTY,
+          drawtypes::get_either_config_label(name(), "label-focused-empty", "label-focused", DEFAULT_WS_LABEL)));
     this->state_labels.insert(std::make_pair(WORKSPACE_DIMMED, drawtypes::get_optional_config_label(name(), "label-dimmed")));
   }
 

--- a/src/modules/bspwm.cpp
+++ b/src/modules/bspwm.cpp
@@ -67,10 +67,12 @@ BspwmModule::BspwmModule(std::string name_, std::string monitor)
   this->formatter->add(DEFAULT_FORMAT, TAG_LABEL_STATE, { TAG_LABEL_STATE }, { TAG_LABEL_MODE });
 
   if (this->formatter->has(TAG_LABEL_STATE)) {
-    this->state_labels.insert(std::make_pair(WORKSPACE_ACTIVE, drawtypes::get_optional_config_label(name(), "label-active", DEFAULT_WS_LABEL)));
     this->state_labels.insert(std::make_pair(WORKSPACE_OCCUPIED, drawtypes::get_optional_config_label(name(), "label-occupied", DEFAULT_WS_LABEL)));
     this->state_labels.insert(std::make_pair(WORKSPACE_URGENT, drawtypes::get_optional_config_label(name(), "label-urgent", DEFAULT_WS_LABEL)));
     this->state_labels.insert(std::make_pair(WORKSPACE_EMPTY, drawtypes::get_optional_config_label(name(), "label-empty", DEFAULT_WS_LABEL)));
+    this->state_labels.insert(std::make_pair(WORKSPACE_FOCUSED_OCCUPIED, drawtypes::get_optional_config_label(name(), "label-focused-occupied", DEFAULT_WS_LABEL)));
+    this->state_labels.insert(std::make_pair(WORKSPACE_FOCUSED_URGENT, drawtypes::get_optional_config_label(name(), "label-focused-urgent", DEFAULT_WS_LABEL)));
+    this->state_labels.insert(std::make_pair(WORKSPACE_FOCUSED_EMPTY, drawtypes::get_optional_config_label(name(), "label-focused-empty", DEFAULT_WS_LABEL)));
     this->state_labels.insert(std::make_pair(WORKSPACE_DIMMED, drawtypes::get_optional_config_label(name(), "label-dimmed")));
   }
 
@@ -175,12 +177,12 @@ bool BspwmModule::update()
     switch (tag[0]) {
       case 'm': monitor_focused = false; break;
       case 'M': monitor_focused = true; break;
-      case 'F': workspace_flag = WORKSPACE_ACTIVE; break;
-      case 'O': workspace_flag = WORKSPACE_ACTIVE; break;
-      case 'o': workspace_flag = WORKSPACE_OCCUPIED; break;
-      case 'U': workspace_flag = WORKSPACE_URGENT; break;
-      case 'u': workspace_flag = WORKSPACE_URGENT; break;
+      case 'F': workspace_flag = WORKSPACE_FOCUSED_EMPTY; break;
+      case 'O': workspace_flag = WORKSPACE_FOCUSED_OCCUPIED; break;
+      case 'U': workspace_flag = WORKSPACE_FOCUSED_URGENT; break;
       case 'f': workspace_flag = WORKSPACE_EMPTY; break;
+      case 'o': workspace_flag = WORKSPACE_OCCUPIED; break;
+      case 'u': workspace_flag = WORKSPACE_URGENT; break;
       case 'L':
         switch (value[0]) {
           case 0: break;
@@ -254,7 +256,8 @@ bool BspwmModule::build(Builder *builder, std::string tag)
 
     builder->node(ws.get()->label);
 
-    if (ws->flag == WORKSPACE_ACTIVE && this->formatter->has(TAG_LABEL_MODE)) {
+    if ((ws->flag == WORKSPACE_FOCUSED_EMPTY || ws->flag == WORKSPACE_FOCUSED_OCCUPIED || ws->flag == WORKSPACE_FOCUSED_URGENT)
+        && this->formatter->has(TAG_LABEL_MODE)) {
       for (auto &&mode : this->modes)
         builder->node(mode->get());
     }


### PR DESCRIPTION
Hello,

I like to keep the same icons whether a workspace is focused or not, but makes its color change; hence the following commit removing the `WORKSPACE_FOCUSED` flag and replacing it with `WORKSPACE_FOCUSED_{URGENT,EMPTY,OCCUPIED}`.

Do you like the idea?
