### PR TITLE
feat: add padding for values

### DIFF
--- a/include/drawtypes/label.hpp
+++ b/include/drawtypes/label.hpp
@@ -11,6 +11,12 @@ POLYBAR_NS
  */
 
 namespace drawtypes {
+
+  struct bounds {
+    size_t min;
+    size_t max;
+  };
+
   class label;
   using label_t = shared_ptr<label>;
 
@@ -35,7 +41,8 @@ namespace drawtypes {
     explicit label(string text, int font) : m_font(font), m_text(text), m_tokenized(m_text) {}
     explicit label(string text, string foreground = "", string background = "",
         string underline = "", string overline = "", int font = 0, int padding = 0, int margin = 0,
-        size_t maxlen = 0, bool ellipsis = true)
+        size_t maxlen = 0, bool ellipsis = true,
+        const vector<struct bounds>& bound = vector<struct bounds>())
         : m_foreground(foreground)
         , m_background(background)
         , m_underline(underline)
@@ -46,7 +53,8 @@ namespace drawtypes {
         , m_maxlen(maxlen)
         , m_ellipsis(ellipsis)
         , m_text(text)
-        , m_tokenized(m_text) {}
+        , m_tokenized(m_text)
+        , m_token_bounds(bound) {}
 
     string get() const;
     operator bool();
@@ -59,6 +67,9 @@ namespace drawtypes {
 
    private:
     string m_text, m_tokenized;
+    const vector<struct bounds> m_token_bounds;
+    vector<struct bounds>::const_iterator m_token_iterator;
+
   };
 
   label_t load_label(

--- a/include/utils/string.hpp
+++ b/include/utils/string.hpp
@@ -18,6 +18,8 @@ namespace string_util {
   bool compare(const string& s1, const string& s2);
   string replace(const string& haystack, string needle, string repl, size_t start = 0, size_t end = string::npos);
   string replace_all(const string& haystack, string needle, string repl, size_t start = 0, size_t end = string::npos);
+  string replace_all_bounded(const string& haystack, string needle, string replacement,
+    size_t min, size_t max, size_t start = 0, size_t end = string::npos);
   string squeeze(const string& haystack, char needle);
   string strip(const string& haystack, char needle);
   string strip_trailing_newline(const string& haystack);

--- a/src/drawtypes/label.cpp
+++ b/src/drawtypes/label.cpp
@@ -26,7 +26,7 @@ namespace drawtypes {
   }
 
   void label::replace_token(string token, string replacement) {
-    if (m_text.find(token) == string::npos)
+    if (m_text.find(token) == string::npos || m_token_iterator == m_token_bounds.end())
       return;
 
     m_tokenized = string_util::replace_all_bounded(m_tokenized, token, replacement,
@@ -77,12 +77,13 @@ namespace drawtypes {
     name = string_util::ltrim(string_util::rtrim(name, '>'), '<');
 
     string text;
-    string line{text};
 
     if (required)
       text = conf.get<string>(section, name);
     else
       text = conf.get<string>(section, name, def);
+
+    string line{text};
 
     while ((start = line.find('%')) != string::npos && (end = line.find('%', start + 1)) != string::npos) {
       auto token = line.substr(start, end);

--- a/src/utils/string.cpp
+++ b/src/utils/string.cpp
@@ -79,6 +79,20 @@ namespace string_util {
   }
 
   /**
+   * Replace all occurrences with bounded replacement
+   */
+  string replace_all_bounded(const string& haystack, string needle, string replacement,
+    size_t min, size_t max, size_t start, size_t end) {
+    if (max != 0 && replacement.length() > max) {
+      replacement = replacement.erase(max);
+    }
+    else if (min != 0 && replacement.length() < min) {
+      replacement.insert(0, min - replacement.length(), ' ');
+    }
+    return replace_all(haystack, needle, replacement, start, end);
+  }
+
+  /**
    * Replace all consecutive occurrences of needle in haystack
    */
   string squeeze(const string& haystack, char needle) {


### PR DESCRIPTION
Added `string_util::format_minwidth` which allows for padding, expanding upon the `udspeed-minwidth` setting. The values which are most susceptible to shifting (volume, battery, cpu percentage, etc.) now use this function, but it might be beneficial to add it to all numerical values.