### PR TITLE
feat(tags): Add prefix and suffix tags to all formats

### DIFF
--- a/include/modules/meta/base.hpp
+++ b/include/modules/meta/base.hpp
@@ -9,6 +9,7 @@
 #include "components/config.hpp"
 #include "components/logger.hpp"
 #include "components/types.hpp"
+#include "drawtypes/label.hpp"
 #include "errors.hpp"
 #include "utils/concurrency.hpp"
 #include "utils/functional.hpp"
@@ -54,11 +55,28 @@ namespace modules {
   DEFINE_CHILD_ERROR(undefined_format, module_error);
   DEFINE_CHILD_ERROR(undefined_format_tag, module_error);
 
+  inline string tagify(string name) {
+      if (name.find('-') != string::npos) {
+        name.erase(0, name.find('-'));
+      }
+      else
+        name.clear();
+      return name;
+  }
+  inline string tag_prefix(string name) {
+      return "<prefix" + tagify(name) + ">";
+  }
+  inline string tag_suffix(string name) {
+      return "<suffix" + tagify(name) + ">";
+  }
+
   // class definition : module_format {{{
 
   struct module_format {
     string value;
     vector<string> tags;
+    pair<string, label_t> prefix;
+    pair<string, label_t> suffix;
     string fg;
     string bg;
     string ul;

--- a/src/modules/backlight.cpp
+++ b/src/modules/backlight.cpp
@@ -76,6 +76,10 @@ namespace modules {
       builder->node(m_ramp->get_by_percentage(m_percentage));
     } else if (tag == TAG_LABEL) {
       builder->node(m_label);
+    } else if (tag == m_formatter->get(DEFAULT_FORMAT)->prefix.first) {
+      builder->node(m_formatter->get(DEFAULT_FORMAT)->prefix.second);
+    } else if (tag == m_formatter->get(DEFAULT_FORMAT)->suffix.first) {
+      builder->node(m_formatter->get(DEFAULT_FORMAT)->suffix.second);
     } else {
       return false;
     }

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -221,6 +221,7 @@ namespace modules {
    * Generate the module output using defined drawtypes
    */
   bool battery_module::build(builder* builder, const string& tag) const {
+    string format = get_format();
     if (tag == TAG_ANIMATION_CHARGING) {
       builder->node(m_animation_charging->get());
     } else if (tag == TAG_BAR_CAPACITY) {
@@ -233,6 +234,10 @@ namespace modules {
       builder->node(m_label_discharging);
     } else if (tag == TAG_LABEL_FULL) {
       builder->node(m_label_full);
+    } else if (tag == m_formatter->get(format)->prefix.first) {
+      builder->node(m_formatter->get(format)->prefix.second);
+    } else if (tag == m_formatter->get(format)->suffix.first) {
+      builder->node(m_formatter->get(format)->suffix.second);
     } else {
       return false;
     }

--- a/src/modules/bspwm.cpp
+++ b/src/modules/bspwm.cpp
@@ -408,6 +408,10 @@ namespace modules {
       }
 
       return modes_n > 0;
+    } else if (tag == m_formatter->get(DEFAULT_FORMAT)->prefix.first) {
+      builder->node(m_formatter->get(DEFAULT_FORMAT)->prefix.second);
+    } else if (tag == m_formatter->get(DEFAULT_FORMAT)->suffix.first) {
+      builder->node(m_formatter->get(DEFAULT_FORMAT)->suffix.second);
     }
 
     return false;

--- a/src/modules/counter.cpp
+++ b/src/modules/counter.cpp
@@ -23,6 +23,10 @@ namespace modules {
     if (tag == TAG_COUNTER) {
       builder->node(to_string(m_counter));
       return true;
+    } else if (tag == m_formatter->get(DEFAULT_FORMAT)->prefix.first) {
+      builder->node(m_formatter->get(DEFAULT_FORMAT)->prefix.second);
+    } else if (tag == m_formatter->get(DEFAULT_FORMAT)->suffix.first) {
+      builder->node(m_formatter->get(DEFAULT_FORMAT)->suffix.second);
     }
     return false;
   }

--- a/src/modules/cpu.cpp
+++ b/src/modules/cpu.cpp
@@ -83,6 +83,10 @@ namespace modules {
         builder->node(m_rampload_core->get_by_percentage(load));
       }
       builder->node(builder->flush());
+    } else if (tag == m_formatter->get(DEFAULT_FORMAT)->prefix.first) {
+      builder->node(m_formatter->get(DEFAULT_FORMAT)->prefix.second);
+    } else if (tag == m_formatter->get(DEFAULT_FORMAT)->suffix.first) {
+      builder->node(m_formatter->get(DEFAULT_FORMAT)->suffix.second);
     } else {
       return false;
     }

--- a/src/modules/date.cpp
+++ b/src/modules/date.cpp
@@ -49,6 +49,10 @@ namespace modules {
 
     if (!m_formatalt.empty()) {
       m_builder->cmd(mousebtn::LEFT, EVENT_TOGGLE);
+    } else if (tag == m_formatter->get(DEFAULT_FORMAT)->prefix.first) {
+      builder->node(m_formatter->get(DEFAULT_FORMAT)->prefix.second);
+    } else if (tag == m_formatter->get(DEFAULT_FORMAT)->suffix.first) {
+      builder->node(m_formatter->get(DEFAULT_FORMAT)->suffix.second);
     }
 
     builder->node(m_buffer);

--- a/src/modules/fs.cpp
+++ b/src/modules/fs.cpp
@@ -126,6 +126,7 @@ namespace modules {
    */
   bool fs_module::build(builder* builder, const string& tag) const {
     auto& mount = m_mounts[m_index];
+    string format = get_format();
 
     if (tag == TAG_BAR_FREE) {
       builder->node(m_barfree->output(mount->percentage_free));
@@ -148,6 +149,10 @@ namespace modules {
       m_labelunmounted->reset_tokens();
       m_labelunmounted->replace_token("%mountpoint%", mount->mountpoint);
       builder->node(m_labelunmounted);
+    } else if (tag == m_formatter->get(format)->prefix.first) {
+      builder->node(m_formatter->get(format)->prefix.second);
+    } else if (tag == m_formatter->get(format)->suffix.first) {
+      builder->node(m_formatter->get(format)->suffix.second);
     } else {
       return false;
     }

--- a/src/modules/i3.cpp
+++ b/src/modules/i3.cpp
@@ -198,6 +198,10 @@ namespace modules {
         builder->cmd_close();
         builder->cmd_close();
       }
+    } else if (tag == m_formatter->get(DEFAULT_FORMAT)->prefix.first) {
+      builder->node(m_formatter->get(DEFAULT_FORMAT)->prefix.second);
+    } else if (tag == m_formatter->get(DEFAULT_FORMAT)->suffix.first) {
+      builder->node(m_formatter->get(DEFAULT_FORMAT)->suffix.second);
     } else {
       return false;
     }

--- a/src/modules/ipc.cpp
+++ b/src/modules/ipc.cpp
@@ -66,6 +66,10 @@ namespace modules {
   bool ipc_module::build(builder* builder, const string& tag) const {
     if (tag == TAG_OUTPUT) {
       builder->node(m_output);
+    } else if (tag == m_formatter->get(DEFAULT_FORMAT)->prefix.first) {
+      builder->node(m_formatter->get(DEFAULT_FORMAT)->prefix.second);
+    } else if (tag == m_formatter->get(DEFAULT_FORMAT)->suffix.first) {
+      builder->node(m_formatter->get(DEFAULT_FORMAT)->suffix.second);
     } else {
       return false;
     }

--- a/src/modules/memory.cpp
+++ b/src/modules/memory.cpp
@@ -99,6 +99,10 @@ namespace modules {
       builder->node(m_bars.at(memtype::FREE)->output(m_perc.at(memtype::FREE)));
     } else if (tag == TAG_LABEL) {
       builder->node(m_label);
+    } else if (tag == m_formatter->get(DEFAULT_FORMAT)->prefix.first) {
+      builder->node(m_formatter->get(DEFAULT_FORMAT)->prefix.second);
+    } else if (tag == m_formatter->get(DEFAULT_FORMAT)->suffix.first) {
+      builder->node(m_formatter->get(DEFAULT_FORMAT)->suffix.second);
     } else {
       return false;
     }

--- a/src/modules/menu.cpp
+++ b/src/modules/menu.cpp
@@ -75,6 +75,10 @@ namespace modules {
         builder->node(item->label);
         builder->cmd_close();
       }
+    } else if (tag == m_formatter->get(DEFAULT_FORMAT)->prefix.first) {
+      builder->node(m_formatter->get(DEFAULT_FORMAT)->prefix.second);
+    } else if (tag == m_formatter->get(DEFAULT_FORMAT)->suffix.first) {
+      builder->node(m_formatter->get(DEFAULT_FORMAT)->suffix.second);
     } else {
       return false;
     }

--- a/src/modules/meta/base.cpp
+++ b/src/modules/meta/base.cpp
@@ -60,8 +60,17 @@ namespace modules {
 
   void module_formatter::add(string name, string fallback, vector<string>&& tags, vector<string>&& whitelist) {
     auto format = make_unique<module_format>();
+    auto prefix = tag_prefix(name);
+    auto suffix = tag_suffix(name);
+
+    tags.emplace_back(prefix);
+    tags.emplace_back(suffix);
 
     format->value = m_conf.get<string>(m_modname, name, move(fallback));
+    format->prefix = make_pair(prefix,
+      load_optional_label(m_conf, m_modname, prefix.substr(1, prefix.size() - 2), ""));
+    format->suffix = make_pair(suffix,
+      load_optional_label(m_conf, m_modname, suffix.substr(1, prefix.size() - 2), ""));
     format->fg = m_conf.get<string>(m_modname, name + "-foreground", "");
     format->bg = m_conf.get<string>(m_modname, name + "-background", "");
     format->ul = m_conf.get<string>(m_modname, name + "-underline", "");

--- a/src/modules/mpd.cpp
+++ b/src/modules/mpd.cpp
@@ -259,6 +259,7 @@ namespace modules {
     bool is_paused = false;
     bool is_stopped = true;
     int elapsed_percentage = 0;
+    string format = get_format();
 
     if (m_status) {
       elapsed_percentage = m_status->get_elapsed_percentage();
@@ -308,6 +309,10 @@ namespace modules {
       icon_cmd(string(EVENT_SEEK).append("-5"), m_icons->get("seekb"));
     } else if (tag == TAG_ICON_SEEKF) {
       icon_cmd(string(EVENT_SEEK).append("+5"), m_icons->get("seekf"));
+    } else if (tag == m_formatter->get(format)->prefix.first) {
+      builder->node(m_formatter->get(format)->prefix.second);
+    } else if (tag == m_formatter->get(format)->suffix.first) {
+      builder->node(m_formatter->get(format)->suffix.second);
     } else {
       return false;
     }

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -147,6 +147,7 @@ namespace modules {
   }
 
   bool network_module::build(builder* builder, const string& tag) const {
+    string format = get_format();
     if (tag == TAG_LABEL_CONNECTED) {
       builder->node(m_label.at(connection_state::CONNECTED));
     } else if (tag == TAG_LABEL_DISCONNECTED) {
@@ -159,6 +160,10 @@ namespace modules {
       builder->node(m_ramp_signal->get_by_percentage(m_signal));
     } else if (tag == TAG_RAMP_QUALITY) {
       builder->node(m_ramp_quality->get_by_percentage(m_quality));
+    } else if (tag == m_formatter->get(format)->prefix.first) {
+      builder->node(m_formatter->get(format)->prefix.second);
+    } else if (tag == m_formatter->get(format)->suffix.first) {
+      builder->node(m_formatter->get(format)->suffix.second);
     } else {
       return false;
     }

--- a/src/modules/script.cpp
+++ b/src/modules/script.cpp
@@ -139,6 +139,10 @@ namespace modules {
       builder->node(m_output);
     } else if (tag == TAG_LABEL) {
       builder->node(m_label);
+    } else if (tag == m_formatter->get(DEFAULT_FORMAT)->prefix.first) {
+      builder->node(m_formatter->get(DEFAULT_FORMAT)->prefix.second);
+    } else if (tag == m_formatter->get(DEFAULT_FORMAT)->suffix.first) {
+      builder->node(m_formatter->get(DEFAULT_FORMAT)->suffix.second);
     } else {
       return false;
     }

--- a/src/modules/temperature.cpp
+++ b/src/modules/temperature.cpp
@@ -67,12 +67,17 @@ namespace modules {
   }
 
   bool temperature_module::build(builder* builder, const string& tag) const {
+    string format = get_format();
     if (tag == TAG_LABEL) {
       builder->node(m_label.at(temp_state::NORMAL));
     } else if (tag == TAG_LABEL_WARN) {
       builder->node(m_label.at(temp_state::WARN));
     } else if (tag == TAG_RAMP) {
       builder->node(m_ramp->get_by_percentage(m_perc));
+    } else if (tag == m_formatter->get(format)->prefix.first) {
+      builder->node(m_formatter->get(format)->prefix.second);
+    } else if (tag == m_formatter->get(format)->suffix.first) {
+      builder->node(m_formatter->get(format)->suffix.second);
     } else {
       return false;
     }

--- a/src/modules/volume.cpp
+++ b/src/modules/volume.cpp
@@ -189,6 +189,7 @@ namespace modules {
   }
 
   bool volume_module::build(builder* builder, const string& tag) const {
+    string format = get_format();
     if (tag == TAG_BAR_VOLUME) {
       builder->node(m_bar_volume->output(m_volume));
     } else if (tag == TAG_RAMP_VOLUME && (!m_headphones || !*m_ramp_headphones)) {
@@ -199,6 +200,10 @@ namespace modules {
       builder->node(m_label_volume);
     } else if (tag == TAG_LABEL_MUTED) {
       builder->node(m_label_muted);
+    } else if (tag == m_formatter->get(format)->prefix.first) {
+      builder->node(m_formatter->get(format)->prefix.second);
+    } else if (tag == m_formatter->get(format)->suffix.first) {
+      builder->node(m_formatter->get(format)->suffix.second);
     } else {
       return false;
     }

--- a/src/modules/xbacklight.cpp
+++ b/src/modules/xbacklight.cpp
@@ -159,6 +159,10 @@ namespace modules {
       builder->node(m_ramp->get_by_percentage(m_percentage));
     } else if (tag == TAG_LABEL) {
       builder->node(m_label);
+    } else if (tag == m_formatter->get(DEFAULT_FORMAT)->prefix.first) {
+      builder->node(m_formatter->get(DEFAULT_FORMAT)->prefix.second);
+    } else if (tag == m_formatter->get(DEFAULT_FORMAT)->suffix.first) {
+      builder->node(m_formatter->get(DEFAULT_FORMAT)->suffix.second);
     } else {
       return false;
     }

--- a/src/modules/xkeyboard.cpp
+++ b/src/modules/xkeyboard.cpp
@@ -107,6 +107,10 @@ namespace modules {
         builder->node(indicator.second);
       }
       return n > 0;
+    } else if (tag == m_formatter->get(DEFAULT_FORMAT)->prefix.first) {
+      builder->node(m_formatter->get(DEFAULT_FORMAT)->prefix.second);
+    } else if (tag == m_formatter->get(DEFAULT_FORMAT)->suffix.first) {
+      builder->node(m_formatter->get(DEFAULT_FORMAT)->suffix.second);
     } else {
       return false;
     }

--- a/src/modules/xwindow.cpp
+++ b/src/modules/xwindow.cpp
@@ -159,6 +159,10 @@ namespace modules {
   bool xwindow_module::build(builder* builder, const string& tag) const {
     if (tag == TAG_LABEL) {
       builder->node(m_label);
+    } else if (tag == m_formatter->get(DEFAULT_FORMAT)->prefix.first) {
+      builder->node(m_formatter->get(DEFAULT_FORMAT)->prefix.second);
+    } else if (tag == m_formatter->get(DEFAULT_FORMAT)->suffix.first) {
+      builder->node(m_formatter->get(DEFAULT_FORMAT)->suffix.second);
     } else {
       return false;
     }

--- a/src/modules/xworkspaces.cpp
+++ b/src/modules/xworkspaces.cpp
@@ -223,6 +223,10 @@ namespace modules {
       }
 
       return num > 0;
+    } else if (tag == m_formatter->get(DEFAULT_FORMAT)->prefix.first) {
+      builder->node(m_formatter->get(DEFAULT_FORMAT)->prefix.second);
+    } else if (tag == m_formatter->get(DEFAULT_FORMAT)->suffix.first) {
+      builder->node(m_formatter->get(DEFAULT_FORMAT)->suffix.second);
     }
 
     return false;


### PR DESCRIPTION
Here's my attempt at implementing prefix and suffix tags for all formats, as per my feature request in #84.

Prefixes and suffixes are named similarly to their formats (`format-charging` -> `<prefix-charging>`) if there are multiple formats, or just `<prefix>` when there is only one.