### PR TITLE
feat: Add left and right padding and margins

### DIFF
--- a/include/drawtypes/label.hpp
+++ b/include/drawtypes/label.hpp
@@ -2,6 +2,7 @@
 
 #include "common.hpp"
 #include "components/config.hpp"
+#include "components/types.hpp"
 #include "utils/mixins.hpp"
 
 POLYBAR_NS
@@ -16,11 +17,6 @@ namespace drawtypes {
     size_t min;
     size_t max;
     string suffix{""};
-  };
-
-  struct sides {
-    int left;
-    int right;
   };
 
   class label;
@@ -39,14 +35,14 @@ namespace drawtypes {
     string m_underline;
     string m_overline;
     int m_font = 0;
-    struct sides m_padding = {0,0};
-    struct sides m_margin = {0,0};
+    struct side_values m_padding = {0,0};
+    struct side_values m_margin = {0,0};
     size_t m_maxlen = 0;
     bool m_ellipsis = true;
 
     explicit label(string text, int font) : m_font(font), m_text(text), m_tokenized(m_text) {}
     explicit label(string text, string foreground = "", string background = "", string underline = "",
-        string overline = "", int font = 0, struct sides padding = {0,0}, struct sides margin = {0,0},
+        string overline = "", int font = 0, struct side_values padding = {0,0}, struct side_values margin = {0,0},
         size_t maxlen = 0, bool ellipsis = true, vector<token>&& tokens = {})
         : m_foreground(foreground)
         , m_background(background)

--- a/include/drawtypes/label.hpp
+++ b/include/drawtypes/label.hpp
@@ -18,6 +18,11 @@ namespace drawtypes {
     string suffix{""};
   };
 
+  struct sides {
+    int left;
+    int right;
+  };
+
   class label;
   using label_t = shared_ptr<label>;
 
@@ -34,15 +39,15 @@ namespace drawtypes {
     string m_underline;
     string m_overline;
     int m_font = 0;
-    int m_padding = 0;
-    int m_margin = 0;
+    struct sides m_padding = {0,0};
+    struct sides m_margin = {0,0};
     size_t m_maxlen = 0;
     bool m_ellipsis = true;
 
     explicit label(string text, int font) : m_font(font), m_text(text), m_tokenized(m_text) {}
     explicit label(string text, string foreground = "", string background = "", string underline = "",
-        string overline = "", int font = 0, int padding = 0, int margin = 0, size_t maxlen = 0, bool ellipsis = true,
-        vector<token>&& tokens = {})
+        string overline = "", int font = 0, struct sides padding = {0,0}, struct sides margin = {0,0},
+        size_t maxlen = 0, bool ellipsis = true, vector<token>&& tokens = {})
         : m_foreground(foreground)
         , m_background(background)
         , m_underline(underline)

--- a/src/components/builder.cpp
+++ b/src/components/builder.cpp
@@ -196,9 +196,8 @@ void builder::node(const label_t& label, bool add_space) {
   // if ((label->m_underline.empty() && m_tags[syntaxtag::u] > 0) || (m_tags[syntaxtag::u] > 0 && label->m_margin > 0))
   //   underline_close();
 
-  // TODO: Replace with margin-left
-  if (label->m_margin > 0) {
-    space(label->m_margin);
+  if (label->m_margin.left > 0) {
+    space(label->m_margin.left);
   }
 
   if (!label->m_overline.empty()) {
@@ -215,16 +214,14 @@ void builder::node(const label_t& label, bool add_space) {
     color(label->m_foreground);
   }
 
-  // TODO: Replace with padding-left
-  if (label->m_padding > 0) {
-    space(label->m_padding);
+  if (label->m_padding.left > 0) {
+    space(label->m_padding.left);
   }
 
   node(text, label->m_font, add_space);
 
-  // TODO: Replace with padding-right
-  if (label->m_padding > 0) {
-    space(label->m_padding);
+  if (label->m_padding.right > 0) {
+    space(label->m_padding.right);
   }
 
   if (!label->m_background.empty()) {
@@ -234,16 +231,15 @@ void builder::node(const label_t& label, bool add_space) {
     color_close();
   }
 
-  if (!label->m_underline.empty() || (label->m_margin > 0 && m_tags[syntaxtag::u] > 0)) {
+  if (!label->m_underline.empty() || (label->m_margin.right > 0 && m_tags[syntaxtag::u] > 0)) {
     underline_close();
   }
-  if (!label->m_overline.empty() || (label->m_margin > 0 && m_tags[syntaxtag::o] > 0)) {
+  if (!label->m_overline.empty() || (label->m_margin.right > 0 && m_tags[syntaxtag::o] > 0)) {
     overline_close();
   }
 
-  // TODO: Replace with margin-right
-  if (label->m_margin > 0) {
-    space(label->m_margin);
+  if (label->m_margin.right > 0) {
+    space(label->m_margin.right);
   }
 }
 

--- a/src/drawtypes/label.cpp
+++ b/src/drawtypes/label.cpp
@@ -64,11 +64,17 @@ namespace drawtypes {
     if (label->m_font != 0) {
       m_font = label->m_font;
     }
-    if (label->m_padding != 0) {
-      m_padding = label->m_padding;
+    if (label->m_padding.left != 0) {
+      m_padding.left = label->m_padding.left;
     }
-    if (label->m_margin != 0) {
-      m_margin = label->m_margin;
+    if (label->m_padding.right != 0) {
+      m_padding.right = label->m_padding.right;
+    }
+    if (label->m_margin.left != 0) {
+      m_margin.left = label->m_margin.left;
+    }
+    if (label->m_margin.right != 0) {
+      m_margin.right = label->m_margin.right;
     }
     if (label->m_maxlen != 0) {
       m_maxlen = label->m_maxlen;
@@ -92,11 +98,17 @@ namespace drawtypes {
     if (m_font == 0 && label->m_font != 0) {
       m_font = label->m_font;
     }
-    if (m_padding == 0 && label->m_padding != 0) {
-      m_padding = label->m_padding;
+    if (m_padding.left == 0 && label->m_padding.left != 0) {
+      m_padding.left = label->m_padding.left;
     }
-    if (m_margin == 0 && label->m_margin != 0) {
-      m_margin = label->m_margin;
+    if (m_padding.right == 0 && label->m_padding.right != 0) {
+      m_padding.right = label->m_padding.right;
+    }
+    if (m_margin.left == 0 && label->m_margin.left != 0) {
+      m_margin.left = label->m_margin.left;
+    }
+    if (m_margin.right == 0 && label->m_margin.right != 0) {
+      m_margin.right = label->m_margin.right;
     }
     if (m_maxlen == 0 && label->m_maxlen != 0) {
       m_maxlen = label->m_maxlen;
@@ -115,11 +127,32 @@ namespace drawtypes {
 
     string text;
 
+    struct sides padding, margin;
+
     if (required) {
       text = conf.get<string>(section, name);
     } else {
       text = conf.get<string>(section, name, move(def));
     }
+
+    const auto get_left_right = [&](string key) {
+      int left = conf.get<int>(section, key + "-left", 0),
+          right = conf.get<int>(section, key + "-right", 0),
+          all = conf.get<int>(section, key, 0);
+
+      if(all > 0) {
+        if(left > 0 || right > 0)
+          throw value_error("Multiple definitions for " + key);
+        else {
+          left = all;
+          right = all;
+        }
+      }
+      return sides {left, right};
+    };
+
+    padding = get_left_right(name + "-padding");
+    margin = get_left_right(name + "-margin");
 
     string line{text};
 
@@ -180,8 +213,8 @@ namespace drawtypes {
         conf.get<string>(section, name + "-underline", ""),
         conf.get<string>(section, name + "-overline", ""),
         conf.get<int>(section, name + "-font", 0),
-        conf.get<int>(section, name + "-padding", 0),
-        conf.get<int>(section, name + "-margin", 0),
+        padding,
+        margin,
         conf.get<size_t>(section, name + "-maxlen", 0),
         conf.get<bool>(section, name + "-ellipsis", true),
         move(tokens));

--- a/src/drawtypes/label.cpp
+++ b/src/drawtypes/label.cpp
@@ -127,7 +127,7 @@ namespace drawtypes {
 
     string text;
 
-    struct sides padding, margin;
+    struct side_values padding, margin;
 
     if (required) {
       text = conf.get<string>(section, name);
@@ -139,7 +139,7 @@ namespace drawtypes {
       auto value = conf.get<int>(section, key, 0);
       auto left = conf.get<int>(section, key + "-left", value);
       auto right = conf.get<int>(section, key + "-right", value);
-      return side_values {left, right};
+      return side_values {static_cast<uint16_t>(left), static_cast<uint16_t>(right)};
     };
 
     padding = get_left_right(name + "-padding");

--- a/src/drawtypes/label.cpp
+++ b/src/drawtypes/label.cpp
@@ -136,19 +136,10 @@ namespace drawtypes {
     }
 
     const auto get_left_right = [&](string key) {
-      int left = conf.get<int>(section, key + "-left", 0),
-          right = conf.get<int>(section, key + "-right", 0),
-          all = conf.get<int>(section, key, 0);
-
-      if(all > 0) {
-        if(left > 0 || right > 0)
-          throw value_error("Multiple definitions for " + key);
-        else {
-          left = all;
-          right = all;
-        }
-      }
-      return sides {left, right};
+      auto value = conf.get<int>(section, key, 0);
+      auto left = conf.get<int>(section, key + "-left", value);
+      auto right = conf.get<int>(section, key + "-right", value);
+      return side_values {left, right};
     };
 
     padding = get_left_right(name + "-padding");


### PR DESCRIPTION
Since the `prefix` and `suffix` strings don't have spaces before/after, having separate left/right padding and margins is the only way to insert a space between them and the rest of the output.