### PR TITLE
Improvement of alsa::mixer and the volume module

### DIFF
--- a/include/adapters/alsa/mixer.hpp
+++ b/include/adapters/alsa/mixer.hpp
@@ -18,13 +18,14 @@ POLYBAR_NS
 namespace alsa {
   class mixer {
    public:
-    explicit mixer(string&& mixer_selem_name);
+    explicit mixer(string&& mixer_selem_name, string&& sound_card_name);
     ~mixer();
 
     mixer(const mixer& o) = delete;
     mixer& operator=(const mixer& o) = delete;
 
     const string& get_name();
+    const string& get_sound_card();
 
     bool wait(int timeout = -1);
     int process_events();
@@ -42,6 +43,7 @@ namespace alsa {
     snd_mixer_elem_t* m_elem{nullptr};
 
     string m_name;
+    string s_name;
   };
 }
 

--- a/src/adapters/alsa/mixer.cpp
+++ b/src/adapters/alsa/mixer.cpp
@@ -12,7 +12,7 @@ namespace alsa {
   /**
    * Construct mixer object
    */
-  mixer::mixer(string&& mixer_selem_name) : m_name(forward<string>(mixer_selem_name)) {
+  mixer::mixer(string&& mixer_selem_name, string&& soundcard_name) : m_name(forward<string>(mixer_selem_name)), s_name(soundcard_name) {
     int err = 0;
 
     if ((err = snd_mixer_open(&m_mixer, 1)) == -1) {
@@ -21,7 +21,7 @@ namespace alsa {
 
     snd_config_update_free_global();
 
-    if ((err = snd_mixer_attach(m_mixer, ALSA_SOUNDCARD)) == -1) {
+    if ((err = snd_mixer_attach(m_mixer, s_name.c_str())) == -1) {
       throw_exception<mixer_error>("Failed to attach hardware mixer control", err);
     }
     if ((err = snd_mixer_selem_register(m_mixer, nullptr, nullptr)) == -1) {
@@ -55,6 +55,13 @@ namespace alsa {
    */
   const string& mixer::get_name() {
     return m_name;
+  }
+
+  /**
+   * Get the name of the soundcard that is associated with the mixer
+   */
+  const string& mixer::get_sound_card() { 
+    return s_name;
   }
 
   /**


### PR DESCRIPTION
Because the "Master mixer" of the default soundcard does not work, I implemented a way to set a soundcard for the master, speaker and headphone mixer.

To set the soundcard(s):
```
[...]
[module/volume]
master-soundcard = <soundcard's name>
speaker-soundcard = <soundcard's name>
headphone-soundcard = <soundcard's name>
[...]
```
I tested this by setting the ```master-soundcard``` to (in my case) ```hw:2```, which is - in my case - an external USB soundcard.