### PR TITLE
Gives priority to __NET_WM_NAME 

### DIFF
--- a/src/modules/xwindow.cpp
+++ b/src/modules/xwindow.cpp
@@ -42,15 +42,15 @@ namespace modules {
 
   /**
    * Get the title by returning the first non-empty value of:
-   *  _NET_WM_VISIBLE_NAME
    *  _NET_WM_NAME
+   *  _NET_WM_VISIBLE_NAME
    */
   string active_window::title(xcb_ewmh_connection_t* ewmh) const {
     string title;
 
-    if (!(title = ewmh_util::get_visible_name(ewmh, m_window)).empty()) {
+    if (!(title = ewmh_util::get_wm_name(ewmh, m_window)).empty()) {
       return title;
-    } else if (!(title = ewmh_util::get_wm_name(ewmh, m_window)).empty()) {
+    } else if (!(title = ewmh_util::get_visible_name(ewmh, m_window)).empty()) {
       return title;
     } else if (!(title = icccm_util::get_wm_name(m_connection, m_window)).empty()) {
       return title;


### PR DESCRIPTION
There is an issue when using the Xwindow module. By default, it will use the __NET_WM_VISIBLE_NAME property to set the title, unless it's empty. This property displays certain characters (like the apostrophe) as "\&apos;" in Firefox, or any other window which uses HTML or similar code. In i3, for example, using the "title_format" command:
`for_window [floating] title_format "<span font=FontName> %title </span>" `
will display the whole string in the bar, instead of the formatted title. 
The __NET_WM_NAME property, however, shows the title correctly. 
