### PR TITLE
Fix for #356

### DIFF
--- a/src/x11/xresources.cpp
+++ b/src/x11/xresources.cpp
@@ -23,6 +23,8 @@ xresource_manager::xresource_manager(Display* dsp) {
 
   if ((m_manager = XResourceManagerString(dsp)) != nullptr) {
     m_db = XrmGetStringDatabase(m_manager);
+  } else {
+    m_db = nullptr;
   }
 }
 


### PR DESCRIPTION
Makes sure `m_db` is a `nullptr` when it is unable to get the X resource manager.
Refs #356 