### PR TITLE
feat(bspwm,i3): Fuzzy-matching names for icons

### DIFF
--- a/include/drawtypes/iconset.hpp
+++ b/include/drawtypes/iconset.hpp
@@ -13,7 +13,7 @@ namespace drawtypes {
    public:
     void add(string id, icon_t&& icon);
     bool has(const string& id);
-    icon_t get(const string& id, const string& fallback_id = "");
+    icon_t get(const string& id, const string& fallback_id = "", bool fuzzy_match = false);
     operator bool();
 
    protected:

--- a/include/modules/bspwm.hpp
+++ b/include/modules/bspwm.hpp
@@ -79,6 +79,7 @@ namespace modules {
     bool m_pinworkspaces{true};
     bool m_inlinemode{false};
     string_util::hash_type m_hash{0U};
+    bool m_fuzzy_match{false};
 
     // used while formatting output
     size_t m_index{0U};

--- a/include/modules/i3.hpp
+++ b/include/modules/i3.hpp
@@ -72,6 +72,7 @@ namespace modules {
     bool m_indexsort{false};
     bool m_pinworkspaces{false};
     bool m_strip_wsnumbers{false};
+    bool m_fuzzy_match{false};
 
     unique_ptr<i3_util::connection_t> m_ipc;
   };

--- a/src/drawtypes/iconset.cpp
+++ b/src/drawtypes/iconset.cpp
@@ -11,7 +11,17 @@ namespace drawtypes {
     return m_icons.find(id) != m_icons.end();
   }
 
-  icon_t iconset::get(const string& id, const string& fallback_id) {
+  icon_t iconset::get(const string& id, const string& fallback_id, bool fuzzy_match) {
+    if (fuzzy_match) {
+      for (auto const& ent1 : m_icons) {
+        if (id.find(ent1.first) != std::string::npos) {
+          return ent1.second;
+        }
+      }
+      return m_icons.find(fallback_id)->second;
+    }
+
+    // Not fuzzy matching so use old method which requires an exact match on icon id
     auto icon = m_icons.find(id);
     if (icon == m_icons.end()) {
       return m_icons.find(fallback_id)->second;

--- a/src/modules/bspwm.cpp
+++ b/src/modules/bspwm.cpp
@@ -56,6 +56,7 @@ namespace modules {
     m_scroll = m_conf.get(name(), "enable-scroll", m_scroll);
     m_revscroll = m_conf.get(name(), "reverse-scroll", m_revscroll);
     m_inlinemode = m_conf.get(name(), "inline-mode", m_inlinemode);
+    m_fuzzy_match = m_conf.get(name(), "fuzzy-match", m_fuzzy_match);
 
     // Add formats and create components
     m_formatter->add(DEFAULT_FORMAT, TAG_LABEL_STATE, {TAG_LABEL_STATE}, {TAG_LABEL_MONITOR, TAG_LABEL_MODE});
@@ -329,7 +330,7 @@ namespace modules {
       }
 
       if (workspace_mask && m_formatter->has(TAG_LABEL_STATE)) {
-        auto icon = m_icons->get(value, DEFAULT_ICON);
+        auto icon = m_icons->get(value, DEFAULT_ICON, m_fuzzy_match);
         auto label = m_statelabels.at(workspace_mask)->clone();
 
         if (!m_monitors.back()->focused) {

--- a/src/modules/i3.cpp
+++ b/src/modules/i3.cpp
@@ -30,6 +30,7 @@ namespace modules {
     m_indexsort = m_conf.get(name(), "index-sort", m_indexsort);
     m_pinworkspaces = m_conf.get(name(), "pin-workspaces", m_pinworkspaces);
     m_strip_wsnumbers = m_conf.get(name(), "strip-wsnumbers", m_strip_wsnumbers);
+    m_fuzzy_match = m_conf.get(name(), "fuzzy-match", m_fuzzy_match);
 
     m_conf.warn_deprecated(name(), "wsname-maxlen", "%name:min:max%");
 
@@ -143,7 +144,7 @@ namespace modules {
         // Trim leading and trailing whitespace
         ws_name = string_util::trim(move(ws_name), ' ');
 
-        auto icon = m_icons->get(ws->name, DEFAULT_WS_ICON);
+        auto icon = m_icons->get(ws->name, DEFAULT_WS_ICON, m_fuzzy_match);
         auto label = m_statelabels.find(ws_state)->second->clone();
 
         label->reset_tokens();


### PR DESCRIPTION
Thanks for this project, I recently switched from i3bar and am loving it! :)

I was playing around with setting icons for different workspaces, and wanted a way to match the icon id as a substring of the workspace name, since my web browser is not always on the same numbered workspace.

I implemented this along with a configuration switch for both bspwm and i3: `fuzzy-match`. It is false by default, which uses the old matching algorithm.

Let me know if anything is not right, I'm still new to c++. Thanks!