### PR TITLE
res_class==NULL to properly get the resource

### DIFF
--- a/include/x11/xresources.hpp
+++ b/include/x11/xresources.hpp
@@ -36,7 +36,7 @@ class xresource_manager {
   template <typename T>
   T require(const char* name) const {
     char* result{nullptr};
-    if (xcb_xrm_resource_get_string(m_xrm, string_util::replace(name, "*", ".").c_str(), "String", &result) == -1) {
+    if (xcb_xrm_resource_get_string(m_xrm, string_util::replace(name, "*", ".").c_str(), nullptr, &result) == -1) {
       throw xresource_error(sstream() << "X resource \"" << name << "\" not found");
     } else if (result == nullptr) {
       throw xresource_error(sstream() << "X resource \"" << name << "\" not found");


### PR DESCRIPTION
Not sure what "String" was supposed to do, my tests with xcb-xrm gives that
res_class==NULL properly gets the resource value, =="String" does not.