### PR TITLE
Ensure reloading when IN_IGNORED fired on config

### DIFF
--- a/include/utils/inotify.hpp
+++ b/include/utils/inotify.hpp
@@ -26,7 +26,7 @@ class inotify_watch {
   void remove(bool force = false);
   bool poll(int wait_ms = 1000) const;
   unique_ptr<inotify_event> get_event() const;
-  bool await_match() const;
+  unique_ptr<inotify_event> await_match() const;
   const string path() const;
   int get_file_descriptor() const;
 

--- a/src/utils/inotify.cpp
+++ b/src/utils/inotify.cpp
@@ -98,8 +98,9 @@ unique_ptr<inotify_event> inotify_watch::get_event() const {
 /**
  * Wait for matching event
  */
-bool inotify_watch::await_match() const {
-  return (get_event()->mask & m_mask) == m_mask;
+unique_ptr<inotify_event> inotify_watch::await_match() const {
+  auto event = get_event();
+  return event->mask & m_mask ? std::move(event) : nullptr;
 }
 
 /**


### PR DESCRIPTION
This fixes a "bug" where polybar wouldn't reload on a configuration file change on some configurations of vim, which don't actually issue any `IN_MODIFY` events because they choose to move the file, replace it with a new one, and then delete the file instead.

To work around this, we now also listen for `IN_IGNORED` which fires when the file we are watching is destroyed. When this happens, we re-attach the configuration file watcher to the new file and reload.