### PR TITLE
fix(label): Truncate label replacements based on codepoint count

### DIFF
--- a/include/utils/string.hpp
+++ b/include/utils/string.hpp
@@ -81,6 +81,9 @@ namespace string_util {
   string rtrim(string&& value, const char& needle = ' ');
   string trim(string&& value, const char& needle = ' ');
 
+  size_t char_len(const string& value);
+  string utf8_truncate(string&& value, size_t len);
+
   string join(const vector<string>& strs, const string& delim);
   vector<string>& split_into(const string& s, char delim, vector<string>& container);
   vector<string> split(const string& s, char delim);

--- a/src/drawtypes/label.cpp
+++ b/src/drawtypes/label.cpp
@@ -48,8 +48,8 @@ namespace drawtypes {
 
     for (auto&& tok : m_tokens) {
       if (token == tok.token) {
-        if (tok.max != 0_z && replacement.length() > tok.max) {
-          replacement = replacement.erase(tok.max) + tok.suffix;
+        if (tok.max != 0_z && string_util::char_len(replacement) > tok.max) {
+          replacement = string_util::utf8_truncate(std::move(replacement), tok.max) + tok.suffix;
         } else if (tok.min != 0_z && replacement.length() < tok.min) {
           replacement.insert(0_z, tok.min - replacement.length(), ' ');
         }


### PR DESCRIPTION
This helps ensure that when a string is truncated it is not done in the middle of a utf8 multi-byte sequence.

This doesn't 100% correspond to user-perceived characters, but it should be pretty close in most cases.

I think this might fix issue #393.
