### PR TITLE
fix(builder): Use unicode-aware truncation for label-maxlen

### DIFF
--- a/src/components/builder.cpp
+++ b/src/components/builder.cpp
@@ -208,8 +208,8 @@ void builder::node(const label_t& label, bool add_space) {
 
   string text{label->get()};
 
-  if (label->m_maxlen > 0 && text.length() > label->m_maxlen) {
-    text = text.substr(0, label->m_maxlen) + "...";
+  if (label->m_maxlen > 0 && string_util::char_len(text) > label->m_maxlen) {
+    text = string_util::utf8_truncate(std::move(text), label->m_maxlen) + "...";
   }
 
   // if ((label->m_overline.empty() && m_tags[syntaxtag::o] > 0) || (m_tags[syntaxtag::o] > 0 && label->m_margin > 0))


### PR DESCRIPTION
This should fix the remaining problems in issue #393, since I missed a spot in the last PR.