### PR TITLE
fix(bspwm): Update when focusing urgent desktops

### DIFF
--- a/include/modules/bspwm.hpp
+++ b/include/modules/bspwm.hpp
@@ -51,6 +51,8 @@ namespace modules {
     bool input(string&& cmd);
 
    private:
+    bool handle_status(string& data);
+
     static constexpr auto DEFAULT_ICON = "ws-icon-default";
     static constexpr auto DEFAULT_LABEL = "%icon% %name%";
     static constexpr auto DEFAULT_MONITOR_LABEL = "%name%";

--- a/src/modules/bspwm.cpp
+++ b/src/modules/bspwm.cpp
@@ -157,12 +157,18 @@ namespace modules {
     }
 
     string data{m_subscriber->receive(BUFSIZ)};
+    bool result = false;
 
-    size_t pos;
-    if ((pos = data.find('\n')) != string::npos) {
-      data.erase(pos);
+    for (auto&& status_line : string_util::split(data, '\n')) {
+      // Need to return true if ANY of the handle_status calls
+      // return true
+      result = this->handle_status(status_line) || result;
     }
 
+    return result;
+  }
+
+  bool bspwm_module::handle_status(string& data) {
     if (data.empty()) {
       return false;
     }
@@ -179,6 +185,8 @@ namespace modules {
     }
 
     m_hash = hash;
+
+    size_t pos;
 
     // Extract the string for the defined monitor
     if (m_pinworkspaces) {


### PR DESCRIPTION
When focusing a desktop with the urgent flag, two events are received
from `bspc` simultaneously, separated by a newline character.

This was not handled correctly and the second event was discarded causing
the urgent style to be removed, but the focused style would remain on the
previously focused desktop.

This fixes the problem by handling any number of events that arrive at the
same time (separated by newlines).