### PR TITLE
install_manifest has a .txt extension

### DIFF
--- a/cmake/templates/uninstall.cmake.in
+++ b/cmake/templates/uninstall.cmake.in
@@ -1,9 +1,9 @@
-set(INSTALL_MANIFEST "@CMAKE_CURRENT_BINARY_DIR@/install_manifest")
+set(INSTALL_MANIFEST "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
 if(NOT EXISTS ${INSTALL_MANIFEST})
   message(FATAL_ERROR "Cannot find install manifest: ${INSTALL_MANIFEST}")
 endif()
 
-file(READ "@CMAKE_CURRENT_BINARY_DIR@/install_manifest" files)
+file(READ ${INSTALL_MANIFEST} files)
 string(REGEX REPLACE "\n" ";" files "${files}")
 list(REVERSE files)
 


### PR DESCRIPTION
As you can see [here](https://cmake.org/Wiki/CMake_FAQ#Can_I_do_.22make_uninstall.22_with_CMake.3F), `install_manifest` file reference in this template is missing an extension.