### PR TITLE
fs: Fix wrong size report

### DIFF
--- a/src/utils/string.cpp
+++ b/src/utils/string.cpp
@@ -257,15 +257,16 @@ namespace string_util {
   /**
    * Create a filesize string by converting given bytes to highest unit possible
    */
-  string filesize(unsigned long long kbytes, size_t precision, bool fixed, const string& locale) {
-    vector<string> suffixes{"TB", "GB", "MB"};
-    string suffix{"KB"};
-    double value = kbytes;
-    while (!suffixes.empty() && (value /= 1024.0) >= 1024.0) {
+  string filesize(unsigned long long bytes, size_t precision, bool fixed, const string& locale) {
+    vector<string> suffixes{"TB", "GB", "MB", "KB"};
+    string suffix{"B"};
+    double value = bytes;
+    while (!suffixes.empty() && value >= 1024.0) {
       suffix = suffixes.back();
       suffixes.pop_back();
+      value /= 1024.0;
     }
-    return floating_point(value, precision, fixed, locale) + " GB";
+    return floating_point(value, precision, fixed, locale) + " " + suffix;
   }
 
   /**

--- a/tests/unit_tests/utils/string.cpp
+++ b/tests/unit_tests/utils/string.cpp
@@ -98,7 +98,11 @@ int main() {
     expect(string_util::filesize_gb(3 * 1024 * 1024 + 200 * 1024, 3) == "3.195 GB");
     expect(string_util::filesize_gb(3 * 1024 * 1024 + 400 * 1024) == "3 GB");
     expect(string_util::filesize_gb(3 * 1024 * 1024 + 800 * 1024) == "4 GB");
-    expect(string_util::filesize(3 * 1024 * 1024) == "3 GB");
+    expect(string_util::filesize(3) == "3 B");
+    expect(string_util::filesize(3 * 1024) == "3 KB");
+    expect(string_util::filesize(3 * 1024 * 1024) == "3 MB");
+    expect(string_util::filesize((unsigned long long)3 * 1024 * 1024 * 1024) == "3 GB");
+    expect(string_util::filesize((unsigned long long)3 * 1024 * 1024 * 1024 * 1024) == "3 TB");
   };
 
   "sstream"_test = [] {


### PR DESCRIPTION
Hi, I found that when the available fs free size was under 1Gb, it reported the right MB size but in GBs (like: 943 GB).

This should fix it