### PR TITLE
feat(mpd): Add state-specific formats

### DIFF
--- a/include/modules/mpd.hpp
+++ b/include/modules/mpd.hpp
@@ -29,6 +29,9 @@ namespace modules {
 
    private:
     static constexpr const char* FORMAT_ONLINE{"format-online"};
+    static constexpr const char* FORMAT_PLAYING{"format-playing"};
+    static constexpr const char* FORMAT_PAUSED{"format-paused"};
+    static constexpr const char* FORMAT_STOPPED{"format-stopped"};
     static constexpr const char* TAG_BAR_PROGRESS{"<bar-progress>"};
     static constexpr const char* TAG_TOGGLE{"<toggle>"};
     static constexpr const char* TAG_TOGGLE_STOP{"<toggle-stop>"};


### PR DESCRIPTION
@jaagr hey, 

This implements #524. 

Basically, in `module_formatter::add()` we check whether `fallback` is a format itself and try to get its value from the config if it is. That allows us to specify `format-online` as a fallback format for `format-playing`, `format-paused` and `format-stopped`.

I guess that the biggest downside to this approach is that we lose the ability to specify a default value in the case where no formats are found in the config. We could avoid that by turning  `fallback` into a vector, but I suppose that would affect all modules, so it might be a bit of an overkill. I'd like to hear your thoughts on this.