### PR TITLE
feat(xwindow): allow pinning window titles to output where the bar is displayed

### DIFF
--- a/include/modules/xwindow.hpp
+++ b/include/modules/xwindow.hpp
@@ -18,6 +18,7 @@ namespace modules {
 
     bool match(const xcb_window_t win) const;
     string title() const;
+    xcb_window_t get_window() const;
 
    private:
     xcb_connection_t* m_connection{nullptr};
@@ -40,10 +41,13 @@ namespace modules {
 
    private:
     static constexpr const char* TAG_LABEL{"<label>"};
+    bool active_window_on_monitor(xcb_window_t window, monitor_t monitor) const;
 
     connection& m_connection;
     unique_ptr<active_window> m_active;
     label_t m_label;
+
+    bool m_pinoutput{false};
   };
 }
 

--- a/src/modules/xwindow.cpp
+++ b/src/modules/xwindow.cpp
@@ -94,8 +94,9 @@ namespace modules {
     free(geom); free(trans);
 
     // if x pos is within monitor width range and y is within height range
-    bool in_x = win_x <= mon->x + mon->w && win_x >= mon->x;
-    bool in_y = win_y <= mon->y + mon->h && win_y >= mon->y;
+    bool in_x = win_x <= mon->x + mon->w - 1 && win_x >= mon->x;
+    bool in_y = win_y <= mon->y + mon->h - 1 && win_y >= mon->y;
+
 
     return in_x && in_y;
   }

--- a/src/modules/xwindow.cpp
+++ b/src/modules/xwindow.cpp
@@ -70,12 +70,16 @@ namespace modules {
       xcb_translate_coordinates_reply_t  *t = xcb_translate_coordinates_reply(m_connection,
         xcb_translate_coordinates(m_connection, window, m_connection.root(), reply->x, reply->y), nullptr);
 
+      free(reply);
+
       int win_x = t->dst_x; // top right
       int win_y = t->dst_y; // top right
 
+      free(t);
+
       // if x pos is within monitor width range and y is within height range
-      bool in_x = win_x <= mon->x + mon->h && win_x >= mon->x;
-      bool in_y = win_y <= mon->y + mon->w && win_y >= mon->y;
+      bool in_x = win_x <= mon->x + mon->w && win_x >= mon->x;
+      bool in_y = win_y <= mon->y + mon->h && win_y >= mon->y;
 
       return in_x && in_y;
     }

--- a/src/modules/xwindow.cpp
+++ b/src/modules/xwindow.cpp
@@ -151,15 +151,20 @@ namespace modules {
     if (m_label) {
       m_label->reset_tokens();
 
+      if (!m_active) {
+        m_label->replace_token("%title%", "");
+        return;
+      }
+
       if (m_pinoutput) {
         if (active_window_on_monitor(m_active->get_window(), m_bar.monitor)) {
-          m_label->replace_token("%title%", m_active ? m_active->title() : "");
+          m_label->replace_token("%title%", m_active->title());
           return;
         } else {
           m_label->replace_token("%title%", "");
         }
       } else {
-        m_label->replace_token("%title%", m_active ? m_active->title() : "");
+        m_label->replace_token("%title%", m_active->title());
       }
     }
   }

--- a/src/modules/xwindow.cpp
+++ b/src/modules/xwindow.cpp
@@ -91,13 +91,11 @@ namespace modules {
       win_y = geom->y;
     }
 
-    free(geom); free(trans);
-
     // if x pos is within monitor width range and y is within height range
     bool in_x = win_x <= mon->x + mon->w - 1 && win_x >= mon->x;
     bool in_y = win_y <= mon->y + mon->h - 1 && win_y >= mon->y;
 
-
+    free(geom); free(trans);
     return in_x && in_y;
   }
 


### PR DESCRIPTION
Having the active window title displayed on all bars did not make sense to me. With this pull request I added a config value to skip displaying the window title on bars on other monitors.

-boolean config property called "pin-output". defaults to false
-window title is only displayed on bar on currently focused monitor
-window geometry from xcb is used to determine a window's position

Fixes #252.