### PR TITLE
manpage: update --quiet description

### DIFF
--- a/man/polybar.1
+++ b/man/polybar.1
@@ -18,7 +18,7 @@ Set the logging verbosity (default: \fBWARNING\fR)
 \fILEVEL\fR is one of: error, warning, info, trace
 .TP
 \fB\-q\fR, \fB\-\-quiet\fR
-Be quiet (will override -l)
+Be quiet (will override -l) (suppresses warnings, errors are still printed to stderr)
 .TP
 \fB\-c\fR, \fB\-\-config\fR=\fIFILE\fR
 Specify the path to the configuration file. By default, the configuration file is loaded from:


### PR DESCRIPTION
even with `--quiet`, errors are printed to `stderr`, but the manpage didn't reflect this detail.

I'd prefer, though, if `polybar --quiet` would print nothing at all, as the name suggests :)