### PR TITLE
fix(fs): Use binary prefixes

### DIFF
--- a/src/utils/string.cpp
+++ b/src/utils/string.cpp
@@ -258,7 +258,7 @@ namespace string_util {
    * Create a filesize string by converting given bytes to highest unit possible
    */
   string filesize(unsigned long long bytes, size_t precision, bool fixed, const string& locale) {
-    vector<string> suffixes{"TB", "GB", "MB", "KB"};
+    vector<string> suffixes{"TiB", "GiB", "MiB", "KiB"};
     string suffix{"B"};
     double value = bytes;
     while (!suffixes.empty() && value >= 1024.0) {

--- a/tests/unit_tests/utils/string.cpp
+++ b/tests/unit_tests/utils/string.cpp
@@ -99,10 +99,10 @@ int main() {
     expect(string_util::filesize_gb(3 * 1024 * 1024 + 400 * 1024) == "3 GB");
     expect(string_util::filesize_gb(3 * 1024 * 1024 + 800 * 1024) == "4 GB");
     expect(string_util::filesize(3) == "3 B");
-    expect(string_util::filesize(3 * 1024) == "3 KB");
-    expect(string_util::filesize(3 * 1024 * 1024) == "3 MB");
-    expect(string_util::filesize((unsigned long long)3 * 1024 * 1024 * 1024) == "3 GB");
-    expect(string_util::filesize((unsigned long long)3 * 1024 * 1024 * 1024 * 1024) == "3 TB");
+    expect(string_util::filesize(3 * 1024) == "3 KiB");
+    expect(string_util::filesize(3 * 1024 * 1024) == "3 MiB");
+    expect(string_util::filesize((unsigned long long)3 * 1024 * 1024 * 1024) == "3 GiB");
+    expect(string_util::filesize((unsigned long long)3 * 1024 * 1024 * 1024 * 1024) == "3 TiB");
   };
 
   "sstream"_test = [] {


### PR DESCRIPTION
Hey, 

I'd like to propose that we switch from using [the SI prefixes](http://physics.nist.gov/cuu/Units/prefixes.html) (**T**B, **G**B, **M**B, **k**B) to [the IEC (binary) ones](http://physics.nist.gov/cuu/Units/binary.html) (**Ti**B, **Gi**B, **Mi**B, **Ki**B). My reasoning for doing so is that SI prefixes are conventionally used to form decimal multiples of units (e.g. 1 **k**B == 1000 B) whereas polybar forms binary multiples:
```C++
while (!suffixes.empty() && value >= 1024.0) { // <-- here
      suffix = suffixes.back();
      suffixes.pop_back();
      value /= 1024.0; // <-- and here
}
```  
SI prefixes are therefore misused:
> Because the SI prefixes strictly represent powers of 10, they should not be used to represent powers of 2. Thus, one kilobit, or 1 kbit, is 1000 bit and not 2**10 bit = 1024 bit. To alleviate this ambiguity, prefixes for binary multiples have been adopted by the International Electrotechnical Commission (IEC) for use in information technology.

It is also worth mentioning that the IEC prefixes are generally adopted in the open-source world, most notably by [the linux kernel](http://man7.org/linux/man-pages/man7/units.7.html) and [GNU Coreutils](https://www.gnu.org/software/coreutils/manual/html_node/Block-size.html), so I believe it would make sense for us to use them as well.

P.S. We could also add an option for SI prefixes to be used (e.g. `si-prefixes = true/false`).