### PR TITLE
Remove curlbuild include

### DIFF
--- a/src/utils/http.cpp
+++ b/src/utils/http.cpp
@@ -1,5 +1,4 @@
 #include <curl/curl.h>
-#include <curl/curlbuild.h>
 #include <curl/easy.h>
 #include <sstream>
 


### PR DESCRIPTION
Curl removed that header in https://github.com/curl/curl/commit/73a2fcea0b4adea6ba342cd7ed1149782c214ae3
http.cpp doesn't use anything from that header and compilation works for
fine with curl 7.54.1

Fixes #647