### PR TITLE
Add textual indicator for module support

### DIFF
--- a/cmake/common/utils.cmake
+++ b/cmake/common/utils.cmake
@@ -14,9 +14,9 @@ endfunction()
 
 function(colored_option text flag)
   if(${flag})
-    message_colored(STATUS "${text}" "32;1")
+    message_colored(STATUS "[X]${text}" "32;1")
   else()
-    message_colored(STATUS "${text}" "37;2")
+    message_colored(STATUS "[ ]${text}" "37;2")
   endif()
 endfunction()
 


### PR DESCRIPTION
If color output was surpressed, there was no way to tell in the cmake                                                              
summary, if a module is actually enabled or not.               
Now each module is prefixed with either a "[X]" to indicate it's enabled                                                           
or a "[ ]" to indicate it's not.

This is something that could have saved a lot of hassle in #644 

EDIT: It now looks like this:
![2017-07-13-003303_294x311_scrot](https://user-images.githubusercontent.com/2452038/28142908-4715a0a4-6763-11e7-968a-8701e6a9f0cb.png)