### PR TITLE
feat(menu): Add expand-right option

### DIFF
--- a/doc/config.cmake
+++ b/doc/config.cmake
@@ -331,6 +331,8 @@ ramp-foreground = ${colors.foreground-alt}
 [module/powermenu]
 type = custom/menu
 
+expand-right = true
+
 format-spacing = 1
 
 label-open = 

--- a/include/modules/menu.hpp
+++ b/include/modules/menu.hpp
@@ -33,6 +33,8 @@ namespace modules {
     static constexpr auto EVENT_MENU_OPEN = "menu-open-";
     static constexpr auto EVENT_MENU_CLOSE = "menu-close";
 
+    bool m_expand_right{true};
+
     label_t m_labelopen;
     label_t m_labelclose;
     label_t m_labelseparator;


### PR DESCRIPTION
expand-right defaults to true to preserve the current functionality
If set to false, the items in the menu will be added to the left of the
toggle label (instead of the right side)

Should resolve the issue discussed in #655 

`expand-right=true`:
![2017-07-16-165654_215x30_scrot](https://user-images.githubusercontent.com/2452038/28248652-2fc834c4-6a48-11e7-8712-47522be829ac.png)
`expand-right=false`:
![2017-07-16-165926_209x32_scrot](https://user-images.githubusercontent.com/2452038/28248653-2ff18644-6a48-11e7-8233-beaf575ebc5b.png)
