### PR TITLE
Fix off by one error for action area

### DIFF
--- a/include/components/types.hpp
+++ b/include/components/types.hpp
@@ -113,7 +113,7 @@ struct action_block : public action {
   }
 
   bool test(int point) const {
-    return static_cast<int>(start_x) < point && static_cast<int>(end_x) >= point;
+    return static_cast<int>(start_x) <= point && static_cast<int>(end_x) > point;
   }
 };
 


### PR DESCRIPTION
If the mouse was at the leftmost edge of the screen and there was an
action area from 0 to N, the click wouldn't register

Before if an action area was defined from A to B it was from A exclusive
to B inclusive now it is from A inclusive to B exclusive. This is the
same way that the pixel addresses work, since a pixel's coordinate is
defined by the top-left corner.

Fixes #661