### PR TITLE
feat(temperature): Add hwmon sysfs support

### DIFF
--- a/src/modules/temperature.cpp
+++ b/src/modules/temperature.cpp
@@ -15,10 +15,13 @@ namespace modules {
   temperature_module::temperature_module(const bar_settings& bar, string name_)
       : timer_module<temperature_module>(bar, move(name_)) {
     m_zone = m_conf.get(name(), "thermal-zone", 0);
+    m_path = m_conf.get(name(), "hwmon-path", ""s);
     m_tempwarn = m_conf.get(name(), "warn-temperature", 80);
     m_interval = m_conf.get<decltype(m_interval)>(name(), "interval", 1s);
 
-    m_path = string_util::replace(PATH_TEMPERATURE_INFO, "%zone%", to_string(m_zone));
+    if (m_path.empty()) {
+      m_path = string_util::replace(PATH_TEMPERATURE_INFO, "%zone%", to_string(m_zone));
+    }
 
     if (!file_util::exists(m_path)) {
       throw module_error("The file '" + m_path + "' does not exist");


### PR DESCRIPTION
Adds support for all temperature data from libsensors. Users should set `hwmon-path` to the full desired sysfs path. Fixes #404.

Helpful tip: first find the desired sensor from `sensors` by looking at `/sys/class/hwmon/hwmon*/temp*_label` or `/sys/class/hwmon/hwmon*/name`, then run `readlink -f /sys/class/hwmon/hwmon*/temp*_input` to find the target of the symlink. Using `/sys/class/hwmon/...` in the config should be avoided because the device orders are not persistent (the order is based on whichever module loads first).