### PR TITLE
fix(cmake): Suppress -Wnoexcept-type warning on GCC

### DIFF
--- a/cmake/01-core.cmake
+++ b/cmake/01-core.cmake
@@ -22,6 +22,11 @@ string(TOUPPER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE_UPPER)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wextra")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+  # there's no way to modify the code to avoid this warning, so we must
+  # suppress it if we use -Werror
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-noexcept-type")
+endif()
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic-errors")


### PR DESCRIPTION
There is no way to avoid this warning in the code itself, so we must suppress this warning if we wish to keep -Werror.

This is part of a series of pull requests that restore building of polybar on GCC. Once this is merged along with jaagr/xpp#6 and jaagr/i3ipcpp#2 (and the submodules updated after those merge), the project should build again with GCC 7.1.