### PR TITLE
fix(modules): Separate prefix/suffix tags, revert tag stack

### DIFF
--- a/include/components/parser.hpp
+++ b/include/components/parser.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <stack>
-
 #include "common.hpp"
 #include "errors.hpp"
 
@@ -30,9 +28,8 @@ class parser {
   void codeblock(string&& data, const bar_settings& bar);
   size_t text(string&& data);
 
-  unsigned int parse_color(std::stack<unsigned int>& color_stack, string& value, unsigned int fallback);
-  unsigned int parse_color_string(const string& s, unsigned int fallback = 0);
-  int parse_fontindex(const string& value);
+  unsigned int parse_color(const string& s, unsigned int fallback = 0);
+  int parse_fontindex(const string& s);
   attribute parse_attr(const char attr);
   mousebtn parse_action_btn(const string& data);
   string parse_action_cmd(string&& data);
@@ -41,12 +38,6 @@ class parser {
   signal_emitter& m_sig;
   vector<int> m_actions;
   unique_ptr<parser> m_parser;
-
-  std::stack<unsigned int> m_fg;
-  std::stack<unsigned int> m_bg;
-  std::stack<unsigned int> m_ul;
-  std::stack<unsigned int> m_ol;
-  std::stack<int> m_fonts;
 };
 
 POLYBAR_NS_END

--- a/src/modules/meta/base.cpp
+++ b/src/modules/meta/base.cpp
@@ -14,6 +14,7 @@ namespace modules {
       builder->flush();
       return "";
     }
+    builder->node(prefix);
 
     if (offset != 0) {
       builder->offset(offset);
@@ -38,9 +39,7 @@ namespace modules {
     }
 
     if (!output.empty()) {
-      builder->node(prefix);
       builder->append(move(output));
-      builder->node(suffix);
     }
 
     if (padding > 0) {
@@ -61,6 +60,7 @@ namespace modules {
     if (margin > 0) {
       builder->space(margin);
     }
+    builder->node(suffix);
 
     return builder->flush();
   }

--- a/src/modules/meta/base.cpp
+++ b/src/modules/meta/base.cpp
@@ -38,9 +38,7 @@ namespace modules {
       builder->space(padding);
     }
 
-    if (!output.empty()) {
-      builder->append(move(output));
-    }
+    builder->append(move(output));
 
     if (padding > 0) {
       builder->space(padding);

--- a/src/modules/meta/base.cpp
+++ b/src/modules/meta/base.cpp
@@ -14,8 +14,6 @@ namespace modules {
       builder->flush();
       return "";
     }
-    builder->node(prefix);
-
     if (offset != 0) {
       builder->offset(offset);
     }
@@ -38,7 +36,23 @@ namespace modules {
       builder->space(padding);
     }
 
+    builder->node(prefix);
+
+    if (!bg.empty()) {
+      builder->background(bg);
+    }
+    if (!fg.empty()) {
+      builder->color(fg);
+    }
+    if (!ul.empty()) {
+      builder->underline(ul);
+    }
+    if (!ol.empty()) {
+      builder->overline(ol);
+    }
+
     builder->append(move(output));
+    builder->node(suffix);
 
     if (padding > 0) {
       builder->space(padding);
@@ -58,7 +72,6 @@ namespace modules {
     if (margin > 0) {
       builder->space(margin);
     }
-    builder->node(suffix);
 
     return builder->flush();
   }


### PR DESCRIPTION
Fixes #639 and #544, as requested by @patrick96. Provides a non-breaking solution to the problem posed in #544.

Stacks are removed (including the font index `%{T}`), but now the tags of prefixes and suffixes are separated from the main output.

There might still be some optimizing to be done, as the reset flag `%{X-}` still sometimes appears when switching between two defined values: `%{B#8d7e45}prefix %{B- B#feffff}main`. Also, module-wide settings (`format-<type>`) are not applied to the prefix and suffix.