### PR TITLE
Fix curl compile errors in aur polybar package

### DIFF
--- a/contrib/polybar.aur/PKGBUILD
+++ b/contrib/polybar.aur/PKGBUILD
@@ -2,7 +2,7 @@
 # Contributor: Michael Carlberg <c@rlberg.se>
 pkgname=polybar
 pkgver=3.0.5
-pkgrel=1
+pkgrel=3
 pkgdesc="A fast and easy-to-use status bar"
 arch=("i686" "x86_64")
 url="https://github.com/jaagr/polybar"
@@ -16,7 +16,7 @@ optdepends=("alsa-lib: volume module support"
             "ttf-unifont: Font used in example config"
             "siji-git: Font used in example config"
             "curl: github module support")
-makedepends=("cmake" "git" "python" "python2" "pkg-config")
+makedepends=("clang" "cmake" "git" "python" "python2" "pkg-config")
 conflicts=("polybar-git")
 install="${pkgname}.install"
 source=("${pkgname}::git+${url}.git#tag=${pkgver}")
@@ -24,12 +24,13 @@ md5sums=("SKIP")
 
 prepare() {
   git -C "${pkgname}" submodule update --init --recursive
+  git -C "${pkgname}" cherry-pick d35abc7620c8f06618b4708d9a969dfa2f309e96
   mkdir -p "${pkgname}/build"
 }
 
 build() {
   cd "${pkgname}/build" || exit 1
-  cmake -DCMAKE_INSTALL_PREFIX=/usr ..
+  cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_C_COMPILER="clang" -DCMAKE_CXX_COMPILER="clang++" ..
   cmake --build .
 }
 


### PR DESCRIPTION
The `curl/curlbuild.h` header issue has been resolved after the last
release, as a consequence the AUR package doesn't build anymore without
altering the source before compiling.

This cherry-picks the fix commit to resolve the compile errors.

@jaagr Can you please update the PKGBUILD for the `polybar` package with the one in this PR