### PR TITLE
fix(date): date and time string limited to 63 chars

### DIFF
--- a/include/modules/date.hpp
+++ b/include/modules/date.hpp
@@ -3,6 +3,10 @@
 #include "modules/meta/input_handler.hpp"
 #include "modules/meta/timer_module.hpp"
 
+#include <iostream>
+#include <iomanip>
+#include <ctime>
+
 POLYBAR_NS
 
 namespace modules {
@@ -34,6 +38,8 @@ namespace modules {
     string m_time;
 
     std::atomic<bool> m_toggled{false};
+
+    void set_stream_locale(std::stringstream &stream);
   };
 }
 

--- a/include/modules/date.hpp
+++ b/include/modules/date.hpp
@@ -37,9 +37,10 @@ namespace modules {
     string m_date;
     string m_time;
 
-    std::atomic<bool> m_toggled{false};
+    // Single stringstream to be used to gather the results of std::put_time
+    std::stringstream datetime_stream;
 
-    void set_stream_locale(std::stringstream &stream);
+    std::atomic<bool> m_toggled{false};
   };
 }
 

--- a/src/modules/date.cpp
+++ b/src/modules/date.cpp
@@ -38,26 +38,36 @@ namespace modules {
     }
   }
 
+  void date_module::set_stream_locale(std::stringstream &stream) {
+    if(!m_bar.locale.empty()) {
+      stream.imbue(std::locale(m_bar.locale.c_str()));
+    }
+  }
+
   bool date_module::update() {
     auto time = std::time(nullptr);
 
     auto date_format = m_toggled ? m_dateformat_alt : m_dateformat;
-    char date_buffer[64]{'\0'};
-    strftime(date_buffer, sizeof(date_buffer), date_format.c_str(), localtime(&time));
+    std::stringstream date_stream; 
+    set_stream_locale(date_stream);
+    date_stream << std::put_time(localtime(&time), date_format.c_str());
+    auto date_string = date_stream.str();
 
     auto time_format = m_toggled ? m_timeformat_alt : m_timeformat;
-    char time_buffer[64]{'\0'};
-    strftime(time_buffer, sizeof(time_buffer), time_format.c_str(), localtime(&time));
+    std::stringstream time_stream; 
+    set_stream_locale(time_stream);
+    time_stream << std::put_time(localtime(&time), time_format.c_str());
+    auto time_string = time_stream.str();
 
-    bool date_changed{strncmp(date_buffer, m_date.c_str(), sizeof(date_buffer)) != 0};
-    bool time_changed{strncmp(time_buffer, m_time.c_str(), sizeof(time_buffer)) != 0};
+    bool date_changed{strncmp(date_string.c_str(), m_date.c_str(), sizeof(date_string)) != 0};
+    bool time_changed{strncmp(time_string.c_str(), m_time.c_str(), sizeof(time_string)) != 0};
 
     if (!date_changed && !time_changed) {
       return false;
     }
 
-    m_date = string{date_buffer};
-    m_time = string{time_buffer};
+    m_date = date_string;
+    m_time = time_string;
 
     if (m_label) {
       m_label->reset_tokens();

--- a/src/modules/date.cpp
+++ b/src/modules/date.cpp
@@ -10,7 +10,6 @@ namespace modules {
 
   date_module::date_module(const bar_settings& bar, string name_) : timer_module<date_module>(bar, move(name_)) {
     if (!m_bar.locale.empty()) {
-      setlocale(LC_TIME, m_bar.locale.c_str());
       datetime_stream.imbue(std::locale(m_bar.locale.c_str()));
     }
 

--- a/src/modules/date.cpp
+++ b/src/modules/date.cpp
@@ -53,10 +53,7 @@ namespace modules {
     datetime_stream << std::put_time(localtime(&time), time_format.c_str());
     auto time_string = datetime_stream.str();
 
-    bool date_changed{strncmp(date_string.c_str(), m_date.c_str(), sizeof(date_string)) != 0};
-    bool time_changed{strncmp(time_string.c_str(), m_time.c_str(), sizeof(time_string)) != 0};
-
-    if (!date_changed && !time_changed) {
+    if (m_date == date_string && m_time == time_string) {
       return false;
     }
 

--- a/src/modules/date.cpp
+++ b/src/modules/date.cpp
@@ -11,6 +11,7 @@ namespace modules {
   date_module::date_module(const bar_settings& bar, string name_) : timer_module<date_module>(bar, move(name_)) {
     if (!m_bar.locale.empty()) {
       setlocale(LC_TIME, m_bar.locale.c_str());
+      datetime_stream.imbue(std::locale(m_bar.locale.c_str()));
     }
 
     m_dateformat = string_util::trim(m_conf.get(name(), "date", ""s), '"');
@@ -38,26 +39,20 @@ namespace modules {
     }
   }
 
-  void date_module::set_stream_locale(std::stringstream &stream) {
-    if(!m_bar.locale.empty()) {
-      stream.imbue(std::locale(m_bar.locale.c_str()));
-    }
-  }
-
   bool date_module::update() {
     auto time = std::time(nullptr);
 
     auto date_format = m_toggled ? m_dateformat_alt : m_dateformat;
-    std::stringstream date_stream; 
-    set_stream_locale(date_stream);
-    date_stream << std::put_time(localtime(&time), date_format.c_str());
-    auto date_string = date_stream.str();
+    // Clear stream contents
+    datetime_stream.str("");
+    datetime_stream << std::put_time(localtime(&time), date_format.c_str());
+    auto date_string = datetime_stream.str();
 
     auto time_format = m_toggled ? m_timeformat_alt : m_timeformat;
-    std::stringstream time_stream; 
-    set_stream_locale(time_stream);
-    time_stream << std::put_time(localtime(&time), time_format.c_str());
-    auto time_string = time_stream.str();
+    // Clear stream contents
+    datetime_stream.str("");
+    datetime_stream << std::put_time(localtime(&time), time_format.c_str());
+    auto time_string = datetime_stream.str();
 
     bool date_changed{strncmp(date_string.c_str(), m_date.c_str(), sizeof(date_string)) != 0};
     bool time_changed{strncmp(time_string.c_str(), m_time.c_str(), sizeof(time_string)) != 0};


### PR DESCRIPTION
Sensible upper limit of 1024 chars since anything of that length will
not be fully rendered on the bar anyways.

fixes #744