### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,6 +2,7 @@ root = true
 
 [*]
 insert_final_newline = true
+trim_trailing_whitespace = true
 indent_style = space
 indent_size = 2
 charset = utf-8

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+charset = utf-8
+
+[Makefile]
+indent_style = tab
+indent_size = 2


### PR DESCRIPTION
For editors that don't autodetect indent style and size

@NBonaparte can you think of anything else that should be in there?