### PR TITLE
[WIP] fix(config): Handle circular variable dependencies

### DIFF
--- a/include/components/config.hpp
+++ b/include/components/config.hpp
@@ -221,7 +221,7 @@ class config {
       string var_section = path.substr(0, pos);
       string var_key = path.substr(pos + 1);
 
-      if(section == var_section && key == var_key) {
+      if((var_section == section || var_section == "self") && var_key == key) {
         throw value_error("Self referencing variable defined at \"" + section + "." + key + "\"");
       }
 

--- a/include/components/config.hpp
+++ b/include/components/config.hpp
@@ -218,7 +218,14 @@ class config {
     } else if (path.compare(0, 5, "file:") == 0) {
       return dereference_file<T>(path.substr(5));
     } else if ((pos = path.find(".")) != string::npos) {
-      return dereference_local<T>(path.substr(0, pos), path.substr(pos + 1), section);
+      string var_section = path.substr(0, pos);
+      string var_key = path.substr(pos + 1);
+
+      if(section == var_section && key == var_key) {
+        throw value_error("Self referencing variable defined at \"" + section + "." + key + "\"");
+      }
+
+      return dereference_local<T>(var_section, var_key, section);
     } else {
       throw value_error("Invalid reference defined at \"" + section + "." + key + "\"");
     }


### PR DESCRIPTION
As described in #783 using the following inside your config would result in a
segfault:
```dosini
background = ${self.background}
```
This PR fixes this.

Right now general circular dependencies like the following are not handled, as
they require keeping track path that was taken while resolving the variable.
```dosini
[colors]
c1 = ${colors.c2}
c2 = ${colors.c1}
```

Fixed #783