### PR TITLE
Add minimum width to CPU percentage

### DIFF
--- a/doc/config.cmake
+++ b/doc/config.cmake
@@ -193,7 +193,7 @@ interval = 2
 format-prefix = " "
 format-prefix-foreground = ${colors.foreground-alt}
 format-underline = #f90000
-label = %percentage%%
+label = %percentage:2%%
 
 [module/memory]
 type = internal/memory


### PR DESCRIPTION
It's quite obscure where to find that you can set a minimum width for tokens, and CPU usage will oscillate between 0-9 and 10+ quite frequently. I think that adding this to the example config will help users to find out that this feature exists, and avoid this annoying default.