### PR TITLE
Fixed a compilation error on Fedora Rawhide

### DIFF
--- a/src/adapters/alsa/mixer.cpp
+++ b/src/adapters/alsa/mixer.cpp
@@ -136,9 +136,9 @@ namespace alsa {
       return math_util::percentage(vol_total / chan_n, vol_min, vol_max);
     }
 
-    normalized = pow10((vol_total / chan_n - vol_max) / 6000.0);
+    normalized = pow(10, (vol_total / chan_n - vol_max) / 6000.0);
     if (vol_min != SND_CTL_TLV_DB_GAIN_MUTE) {
-      min_norm = pow10((vol_min - vol_max) / 6000.0);
+      min_norm = pow(10, (vol_min - vol_max) / 6000.0);
       normalized = (normalized - min_norm) / (1 - min_norm);
     }
 
@@ -182,7 +182,7 @@ namespace alsa {
     }
 
     if (vol_min != SND_CTL_TLV_DB_GAIN_MUTE) {
-      min_norm = pow10((vol_min - vol_max) / 6000.0);
+      min_norm = pow(10, (vol_min - vol_max) / 6000.0);
       percentage = percentage * (1 - min_norm) + min_norm;
     }
 


### PR DESCRIPTION
I've built rpm packages for fedora and I run into an error on Fedora Rawhide.

`...use of undeclared identifier 'pow10'...`

Looking around this seems a quick fix with pow(10, ...).
It compiles now with these fixes.