### PR TITLE
fix(i3): Check whether current ws is found

### DIFF
--- a/src/modules/i3.cpp
+++ b/src/modules/i3.cpp
@@ -224,6 +224,7 @@ namespace modules {
                                 [](auto ws) { return ws->visible; });
 
       if (current_ws == workspaces.end()) {
+        m_log.warn("%s: Current workspace not found", name());
         return false;
       }
 

--- a/src/modules/i3.cpp
+++ b/src/modules/i3.cpp
@@ -220,20 +220,24 @@ namespace modules {
       }
 
       auto workspaces = i3_util::workspaces(conn, m_bar.monitor->name);
-      auto current_ws = *find_if(workspaces.begin(), workspaces.end(), 
-                                 [](auto ws) { return ws->visible; });
+      auto current_ws = find_if(workspaces.begin(), workspaces.end(),
+                                [](auto ws) { return ws->visible; });
 
-      if (scrolldir == "next" && (m_wrap || workspaces.back() != current_ws)) {
-        if (!current_ws->focused) {
+      if (current_ws == workspaces.end()) {
+        return false;
+      }
+
+      if (scrolldir == "next" && (m_wrap || next(current_ws) != workspaces.end())) {
+        if (!(*current_ws)->focused) {
           m_log.info("%s: Sending workspace focus command to ipc handler", name());
-          conn.send_command("workspace " + current_ws->name);
+          conn.send_command("workspace " + (*current_ws)->name);
         }
         m_log.info("%s: Sending workspace next_on_output command to ipc handler", name());
         conn.send_command("workspace next_on_output");
-      } else if (scrolldir == "prev" && (m_wrap || workspaces.front() != current_ws)) {
-        if (!current_ws->focused) {
+      } else if (scrolldir == "prev" && (m_wrap || current_ws != workspaces.begin())) {
+        if (!(*current_ws)->focused) {
           m_log.info("%s: Sending workspace focus command to ipc handler", name());
-          conn.send_command("workspace " + current_ws->name);
+          conn.send_command("workspace " + (*current_ws)->name);
         }
         m_log.info("%s: Sending workspace prev_on_output command to ipc handler", name());
         conn.send_command("workspace prev_on_output");


### PR DESCRIPTION
Fixes dereference of `end()` iterator in case current workspace is not found (#824).

I'm not sure whether this should be logged or not, so I'd like to hear your opinion on that.