### PR TITLE
fix(renderer): Only draw text bg if the color differs from the bar bg color

### DIFF
--- a/src/components/renderer.cpp
+++ b/src/components/renderer.cpp
@@ -602,7 +602,11 @@ void renderer::draw_text(const string& contents) {
   block.y_advance = &m_blocks[m_align].y;
   block.bg_rect = cairo::rect{0.0, 0.0, 0.0, 0.0};
 
-  if (m_bg) {
+  // Only draw text background if the color differs from
+  // the background color of the bar itself
+  // Note: this means that if the user explicitly set text
+  // background color equal to background-0 it will be ignored
+  if (m_bg != m_bar.background) {
     block.bg = m_bg;
     block.bg_operator = m_comp_bg;
     block.bg_rect.x = m_rect.x;


### PR DESCRIPTION
Fixes #759 by only drawing text background when its color is different from the background color of the bar itself. Original check was made invalid by [this change](https://github.com/jaagr/polybar/commit/0bd8f1f69a8dfdb2f2800a6612c8acb7e6c86ed2#diff-543075e5874c51140b59304a24b67c78L208).

There is one small issue though: if the text background color is explicitly set equal to `background-0` it will be ignored.