### PR TITLE
feat(mpd): Add support for icon-consume

### DIFF
--- a/include/adapters/mpd.hpp
+++ b/include/adapters/mpd.hpp
@@ -107,6 +107,7 @@ namespace mpd {
     void set_repeat(bool mode);
     void set_random(bool mode);
     void set_single(bool mode);
+    void set_consume(bool mode);
 
     operator mpd_connection_t::element_type*();
 
@@ -144,6 +145,7 @@ namespace mpd {
     bool random() const;
     bool repeat() const;
     bool single() const;
+    bool consume() const;
 
     bool match_state(mpdstate state) const;
 
@@ -165,6 +167,7 @@ namespace mpd {
     bool m_random{false};
     bool m_repeat{false};
     bool m_single{false};
+    bool m_consume{false};
 
     int m_songid{0};
     int m_queuelen{0};

--- a/include/modules/mpd.hpp
+++ b/include/modules/mpd.hpp
@@ -40,6 +40,7 @@ namespace modules {
     static constexpr const char* TAG_ICON_RANDOM{"<icon-random>"};
     static constexpr const char* TAG_ICON_REPEAT{"<icon-repeat>"};
     static constexpr const char* TAG_ICON_REPEAT_ONE{"<icon-repeatone>"};
+    static constexpr const char* TAG_ICON_CONSUME{"<icon-consume>"};
     static constexpr const char* TAG_ICON_PREV{"<icon-prev>"};
     static constexpr const char* TAG_ICON_STOP{"<icon-stop>"};
     static constexpr const char* TAG_ICON_PLAY{"<icon-play>"};
@@ -59,6 +60,7 @@ namespace modules {
     static constexpr const char* EVENT_REPEAT{"mpdrepeat"};
     static constexpr const char* EVENT_REPEAT_ONE{"mpdrepeatone"};
     static constexpr const char* EVENT_RANDOM{"mpdrandom"};
+    static constexpr const char* EVENT_CONSUME{"mpdconsume"};
     static constexpr const char* EVENT_SEEK{"mpdseek"};
 
     unique_ptr<mpdconnection> m_mpd;

--- a/src/adapters/mpd.cpp
+++ b/src/adapters/mpd.cpp
@@ -321,6 +321,16 @@ namespace mpd {
     }
   }
 
+  void mpdconnection::set_consume(bool mode) {
+    try {
+      check_prerequisites_commands_list();
+      mpd_run_consume(m_connection.get(), mode);
+      check_errors(m_connection.get());
+    } catch (const mpd_exception& e) {
+      m_log.err("mpdconnection.set_consume: %s", e.what());
+    }
+  }
+
   mpdconnection::operator mpd_connection_t::element_type*() {
     return m_connection.get();
   }
@@ -354,6 +364,7 @@ namespace mpd {
     m_random = mpd_status_get_random(m_status.get());
     m_repeat = mpd_status_get_repeat(m_status.get());
     m_single = mpd_status_get_single(m_status.get());
+    m_consume = mpd_status_get_consume(m_status.get());
     m_elapsed_time = mpd_status_get_elapsed_time(m_status.get());
     m_total_time = mpd_status_get_total_time(m_status.get());
   }
@@ -402,6 +413,10 @@ namespace mpd {
 
   bool mpdstatus::single() const {
     return m_single;
+  }
+
+  bool mpdstatus::consume() const {
+    return m_consume;
   }
 
   bool mpdstatus::match_state(mpdstate state) const {

--- a/src/modules/mpd.cpp
+++ b/src/modules/mpd.cpp
@@ -25,7 +25,7 @@ namespace modules {
       m_formatter->add(format, format_online,
           {TAG_BAR_PROGRESS, TAG_TOGGLE, TAG_TOGGLE_STOP, TAG_LABEL_SONG, TAG_LABEL_TIME, TAG_ICON_RANDOM,
               TAG_ICON_REPEAT, TAG_ICON_REPEAT_ONE, TAG_ICON_PREV, TAG_ICON_STOP, TAG_ICON_PLAY, TAG_ICON_PAUSE,
-              TAG_ICON_NEXT, TAG_ICON_SEEKB, TAG_ICON_SEEKF});
+              TAG_ICON_NEXT, TAG_ICON_SEEKB, TAG_ICON_SEEKF, TAG_ICON_CONSUME});
     }
 
     m_formatter->add(FORMAT_OFFLINE, "", {TAG_LABEL_OFFLINE});
@@ -62,6 +62,9 @@ namespace modules {
     if (m_formatter->has(TAG_ICON_REPEAT_ONE)) {
       m_icons->add("repeat_one", load_icon(m_conf, name(), TAG_ICON_REPEAT_ONE));
     }
+    if (m_formatter->has(TAG_ICON_CONSUME)) {
+      m_icons->add("consume", load_icon(m_conf, name(), TAG_ICON_CONSUME));
+    }
 
     if (m_formatter->has(TAG_LABEL_SONG)) {
       m_label_song = load_optional_label(m_conf, name(), TAG_LABEL_SONG, "%artist% - %title%");
@@ -70,7 +73,7 @@ namespace modules {
       m_label_time = load_optional_label(m_conf, name(), TAG_LABEL_TIME, "%elapsed% / %total%");
     }
     if (m_formatter->has(TAG_ICON_RANDOM) || m_formatter->has(TAG_ICON_REPEAT) ||
-        m_formatter->has(TAG_ICON_REPEAT_ONE)) {
+        m_formatter->has(TAG_ICON_REPEAT_ONE) || m_formatter->has(TAG_ICON_CONSUME)) {
       m_toggle_on_color = m_conf.get(name(), "toggle-on-foreground", ""s);
       m_toggle_off_color = m_conf.get(name(), "toggle-off-foreground", ""s);
     }
@@ -240,6 +243,9 @@ namespace modules {
       m_icons->get("repeat_one")->m_foreground =
           m_status && m_status->single() ? m_toggle_on_color : m_toggle_off_color;
     }
+    if (m_icons->has("consume")) {
+      m_icons->get("consume")->m_foreground = m_status && m_status->consume() ? m_toggle_on_color : m_toggle_off_color;
+    }
 
     return true;
   }
@@ -284,6 +290,8 @@ namespace modules {
       builder->cmd(mousebtn::LEFT, EVENT_REPEAT, m_icons->get("repeat"));
     } else if (tag == TAG_ICON_REPEAT_ONE) {
       builder->cmd(mousebtn::LEFT, EVENT_REPEAT_ONE, m_icons->get("repeat_one"));
+    } else if (tag == TAG_ICON_CONSUME) {
+      builder->cmd(mousebtn::LEFT, EVENT_CONSUME, m_icons->get("consume"));
     } else if (tag == TAG_ICON_PREV) {
       builder->cmd(mousebtn::LEFT, EVENT_PREV, m_icons->get("prev"));
     } else if ((tag == TAG_ICON_STOP || tag == TAG_TOGGLE_STOP) && (is_playing || is_paused)) {
@@ -336,6 +344,8 @@ namespace modules {
         mpd->set_repeat(!status->repeat());
       } else if (cmd == EVENT_RANDOM) {
         mpd->set_random(!status->random());
+      } else if (cmd == EVENT_CONSUME) {
+        mpd->set_consume(!status->consume());
       } else if (cmd.compare(0, strlen(EVENT_SEEK), EVENT_SEEK) == 0) {
         auto s = cmd.substr(strlen(EVENT_SEEK));
         int percentage = 0;


### PR DESCRIPTION
This PR adds support for _icon-consume_ to the mpd module.
It works exactly like _icon-random_ and the alike.