### PR TITLE
fix(AUR): Remove failing call to version.sh

### DIFF
--- a/contrib/polybar-git.aur/PKGBUILD
+++ b/contrib/polybar-git.aur/PKGBUILD
@@ -35,9 +35,6 @@ prepare() {
 
 build() {
   cd "${_pkgname}/build" || exit 1
-  if [ -x ../common/version.sh ]; then
-    ../common/version.sh
-  fi
   cmake -DCMAKE_INSTALL_PREFIX=/usr ..
   cmake --build .
 }


### PR DESCRIPTION
version.sh is supposed to set the `GIT_TAG` macro in `version.hpp` to the
output of `git describe ...`, however it uses relative paths and can't
find `include/version.hpp`

`include/CMakeLists.txt` already has the same functionality so this is
not needed