### PR TITLE
fix(bump.sh): remove references to .SRCINFO

### DIFF
--- a/common/bump.sh
+++ b/common/bump.sh
@@ -17,12 +17,12 @@ main() {
 
   sed -r "s/${tag_prev}/${tag_curr}/g" -i \
     README.md CMakeLists.txt \
-    contrib/polybar.aur/PKGBUILD contrib/polybar.aur/.SRCINFO \
-    contrib/polybar-git.aur/PKGBUILD contrib/polybar-git.aur/.SRCINFO
+    contrib/polybar.aur/PKGBUILD \
+    contrib/polybar-git.aur/PKGBUILD
 
   git add -u README.md CMakeLists.txt \
-    contrib/polybar.aur/PKGBUILD contrib/polybar.aur/.SRCINFO \
-    contrib/polybar-git.aur/PKGBUILD contrib/polybar-git.aur/.SRCINFO \
+    contrib/polybar.aur/PKGBUILD \
+    contrib/polybar-git.aur/PKGBUILD \
     include/version.hpp
 
   git commit -m "build: Bump version to ${tag_curr}"


### PR DESCRIPTION
`common/bump.sh` still refers to .SRCINFO files and fails when run, so we should remove those references.