### PR TITLE
feat(temp): Add temperature tokens without unit

### DIFF
--- a/doc/config.cmake
+++ b/doc/config.cmake
@@ -322,8 +322,8 @@ format-underline = #f50a4d
 format-warn = <ramp> <label-warn>
 format-warn-underline = ${self.format-underline}
 
-label = %temperature%
-label-warn = %temperature%
+label = %temperature-c%
+label-warn = %temperature-c%
 label-warn-foreground = ${colors.secondary}
 
 ramp-0 = 

--- a/include/modules/temperature.hpp
+++ b/include/modules/temperature.hpp
@@ -32,6 +32,9 @@ namespace modules {
     int m_tempwarn = 0;
     int m_temp = 0;
     int m_perc = 0;
+
+    // Whether or not to show units with the %temperature-X% tokens
+    bool m_units{true};
   };
 }
 

--- a/src/modules/temperature.cpp
+++ b/src/modules/temperature.cpp
@@ -19,6 +19,7 @@ namespace modules {
     m_path = m_conf.get(name(), "hwmon-path", ""s);
     m_tempwarn = m_conf.get(name(), "warn-temperature", 80);
     m_interval = m_conf.get<decltype(m_interval)>(name(), "interval", 1s);
+    m_units = m_conf.get(name(), "units", m_units);
 
     if (m_path.empty()) {
       m_path = string_util::replace(PATH_TEMPERATURE_INFO, "%zone%", to_string(m_zone));
@@ -53,15 +54,22 @@ namespace modules {
     int m_temp_f = floor(((1.8 * m_temp) + 32) + 0.5);
     m_perc = math_util::cap(math_util::percentage(m_temp, 0, m_tempwarn), 0, 100);
 
+    string temp_c_string = to_string(m_temp);
+    string temp_f_string = to_string(m_temp_f);
+
+    // Add units if `units = true` in config
+    if(m_units) {
+      temp_c_string += "°C";
+      temp_f_string += "°F";
+    }
+
     const auto replace_tokens = [&](label_t& label) {
       label->reset_tokens();
-      label->replace_token("%temperature-f%", to_string(m_temp_f) + "°F");
-      label->replace_token("%temperature-c%", to_string(m_temp) + "°C");
-      label->replace_token("%temperature-f-n%", to_string(m_temp_f));
-      label->replace_token("%temperature-c-n%", to_string(m_temp));
+      label->replace_token("%temperature-f%", temp_f_string);
+      label->replace_token("%temperature-c%", temp_c_string);
 
       // DEPRECATED: Will be removed in later release
-      label->replace_token("%temperature%", to_string(m_temp) + "°C");
+      label->replace_token("%temperature%", temp_c_string);
     };
 
     if (m_label[temp_state::NORMAL]) {

--- a/src/modules/temperature.cpp
+++ b/src/modules/temperature.cpp
@@ -32,13 +32,19 @@ namespace modules {
     m_formatter->add(FORMAT_WARN, TAG_LABEL_WARN, {TAG_LABEL_WARN, TAG_RAMP});
 
     if (m_formatter->has(TAG_LABEL)) {
-      m_label[temp_state::NORMAL] = load_optional_label(m_conf, name(), TAG_LABEL, "%temperature%");
+      m_label[temp_state::NORMAL] = load_optional_label(m_conf, name(), TAG_LABEL, "%temperature-c%");
     }
     if (m_formatter->has(TAG_LABEL_WARN)) {
-      m_label[temp_state::WARN] = load_optional_label(m_conf, name(), TAG_LABEL_WARN, "%temperature%");
+      m_label[temp_state::WARN] = load_optional_label(m_conf, name(), TAG_LABEL_WARN, "%temperature-c%");
     }
     if (m_formatter->has(TAG_RAMP)) {
       m_ramp = load_ramp(m_conf, name(), TAG_RAMP);
+    }
+
+    // Deprecation warning for the %temperature% token
+    if((m_label[temp_state::NORMAL] && m_label[temp_state::NORMAL]->has_token("%temperature%")) ||
+        ((m_label[temp_state::WARN] && m_label[temp_state::WARN]->has_token("%temperature%")))) {
+      m_log.warn("%s: The token `%%temperature%%` is deprecated, use `%%temperature-c%%` instead.", name());
     }
   }
 
@@ -53,6 +59,8 @@ namespace modules {
       label->replace_token("%temperature-c%", to_string(m_temp) + "°C");
       label->replace_token("%temperature-f-n%", to_string(m_temp_f));
       label->replace_token("%temperature-c-n%", to_string(m_temp));
+
+      // DEPRECATED: Will be removed in later release
       label->replace_token("%temperature%", to_string(m_temp) + "°C");
     };
 

--- a/src/modules/temperature.cpp
+++ b/src/modules/temperature.cpp
@@ -51,6 +51,8 @@ namespace modules {
       label->reset_tokens();
       label->replace_token("%temperature-f%", to_string(m_temp_f) + "°F");
       label->replace_token("%temperature-c%", to_string(m_temp) + "°C");
+      label->replace_token("%temperature-f-n%", to_string(m_temp_f));
+      label->replace_token("%temperature-c-n%", to_string(m_temp));
       label->replace_token("%temperature%", to_string(m_temp) + "°C");
     };
 


### PR DESCRIPTION
Adds two new tokens, `%temperature-c-n%` and`%temperature-f-n%`, to display the temperatures in those respectives scales without the appended unit.
This also deprecates the `%temperature%` token in favor of the scale specific tokens, `%temperature-c%` and `%temperature-f%`