### PR TITLE
xworkspaces: Use _NET_NUMBER_OF_DESKTOPS if _NET_DESKTOP_NAMES is not avaliable

### DIFF
--- a/include/modules/xworkspaces.hpp
+++ b/include/modules/xworkspaces.hpp
@@ -66,6 +66,7 @@ namespace modules {
     void rebuild_clientlist();
     void rebuild_desktops();
     void rebuild_desktop_states();
+    void rebuild_desktop_names();
     void set_desktop_urgent(xcb_window_t window);
 
     bool input(string&& cmd);
@@ -88,6 +89,7 @@ namespace modules {
 
     vector<monitor_t> m_monitors;
     bool m_monitorsupport{true};
+    bool m_desktop_names_support{true};
 
     vector<string> m_desktop_names;
     unsigned int m_current_desktop;

--- a/include/x11/ewmh.hpp
+++ b/include/x11/ewmh.hpp
@@ -23,6 +23,7 @@ namespace ewmh_util {
 
   vector<position> get_desktop_viewports(int screen = 0);
   vector<string> get_desktop_names(int screen = 0);
+  unsigned int get_number_of_desktops(int screen = 0);
   unsigned int get_current_desktop(int screen = 0);
   xcb_window_t get_active_window(int screen = 0);
 

--- a/src/x11/ewmh.cpp
+++ b/src/x11/ewmh.cpp
@@ -99,6 +99,13 @@ namespace ewmh_util {
     return {};
   }
 
+  unsigned int get_number_of_desktops(int screen) {
+    auto conn = initialize().get();
+    unsigned int reply = 0;
+    xcb_ewmh_get_number_of_desktops_reply(conn, xcb_ewmh_get_number_of_desktops(conn, screen), &reply, nullptr);
+    return reply;
+  }
+
   xcb_window_t get_active_window(int screen) {
     auto conn = initialize().get();
     unsigned int win = XCB_NONE;


### PR DESCRIPTION
[windowchef](https://github.com/tudurom/windowchef) is at least one window manager that doesnt support `_NET_DESKTOP_NAMES`. This patch simply falls back to `_NET_NUMBER_OF_DESKTOPS`, and generates names from those numbers.