### PR TITLE
fix(github): libcurl stuck at curl_easy_perform

### DIFF
--- a/src/utils/http.cpp
+++ b/src/utils/http.cpp
@@ -16,6 +16,7 @@ http_downloader::http_downloader(int connection_timeout) {
   curl_easy_setopt(m_curl, CURLOPT_NOSIGNAL, true);
   curl_easy_setopt(m_curl, CURLOPT_USERAGENT, "polybar/" GIT_TAG);
   curl_easy_setopt(m_curl, CURLOPT_WRITEFUNCTION, http_downloader::write);
+  curl_easy_setopt(m_curl, CURLOPT_FORBID_REUSE, true);
 }
 
 http_downloader::~http_downloader() {


### PR DESCRIPTION
When the internet connection is off, the github module stuck at the `curl_easy_perform` function.
Does not really recover from it, it is probably not a polybar/github module issue, but curl.

It can be "fixed" via disabling the shared connection.