### PR TITLE
fix(mpd): Always update mpd data

### DIFF
--- a/include/adapters/mpd.hpp
+++ b/include/adapters/mpd.hpp
@@ -140,7 +140,6 @@ namespace mpd {
 
     void fetch_data(mpdconnection* conn);
     void update(int event, mpdconnection* connection);
-    void update_timer();
 
     bool random() const;
     bool repeat() const;

--- a/src/adapters/mpd.cpp
+++ b/src/adapters/mpd.cpp
@@ -374,7 +374,7 @@ namespace mpd {
      * Only update if either the player state (play, stop, pause, seek, ...), the options (random, repeat, ...),
      * or the playlist has been changed
      */
-    if (connection == nullptr || !static_cast<bool>(event & (MPD_IDLE_PLAYER | MPD_IDLE_OPTIONS | MPD_IDLE_PLAYLIST))) {
+    if (connection == nullptr || !static_cast<bool>(event & (MPD_IDLE_PLAYER | MPD_IDLE_OPTIONS | MPD_IDLE_QUEUE))) {
       return;
     }
 

--- a/src/adapters/mpd.cpp
+++ b/src/adapters/mpd.cpp
@@ -370,6 +370,10 @@ namespace mpd {
   }
 
   void mpdstatus::update(int event, mpdconnection* connection) {
+    /*
+     * Only update if either the player state (play, stop, pause, seek, ...), the options (random, repeat, ...),
+     * or the playlist has been changed
+     */
     if (connection == nullptr || !static_cast<bool>(event & (MPD_IDLE_PLAYER | MPD_IDLE_OPTIONS | MPD_IDLE_PLAYLIST))) {
       return;
     }
@@ -393,14 +397,6 @@ namespace mpd {
       default:
         m_state = mpdstate::UNKNOWN;
     }
-  }
-
-  void mpdstatus::update_timer() {
-    auto diff = chrono::system_clock::now() - m_updated_at;
-    auto dur = chrono::duration_cast<chrono::milliseconds>(diff);
-    m_elapsed_time_ms += dur.count();
-    m_elapsed_time = m_elapsed_time_ms / 1000 + 0.5f;
-    m_updated_at = chrono::system_clock::now();
   }
 
   bool mpdstatus::random() const {

--- a/src/modules/mpd.cpp
+++ b/src/modules/mpd.cpp
@@ -162,12 +162,9 @@ namespace modules {
 
       int idle_flags = 0;
       if ((idle_flags = m_mpd->noidle()) != 0) {
+        // Update status on every event
         m_status->update(idle_flags, m_mpd.get());
         return true;
-      }
-
-      if (m_status->match_state(mpdstate::PLAYING)) {
-        m_status->update_timer();
       }
     } catch (const mpd_exception& err) {
       m_log.err("%s: %s", name(), err.what());
@@ -201,6 +198,11 @@ namespace modules {
       if (connected() && (m_status = m_mpd->get_status_safe())) {
         return false;
       }
+    }
+
+    if (m_status->match_state(mpdstate::PLAYING)) {
+      // Always update the status while playing
+      m_status->update(-1, m_mpd.get());
     }
 
     string artist;


### PR DESCRIPTION
Only updating when an mpd event occurred would cause issues when mpd was
playing and the machine was put to sleep because the elapsed time was
calculated by taking the time difference of the last update and now which
would give you wrong numbers, if the machine was in standby in between.

Since the update function on the module is only called once a second (or
when an event happens), we can just update the data every time without a
huge performance hit.

Fixes #915