### PR TITLE
Added FreeBSD Support

### DIFF
--- a/cmake/01-core.cmake
+++ b/cmake/01-core.cmake
@@ -31,8 +31,17 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic-errors")
 
+if (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+  # Need dprintf() for FreeBSD 11.1 and older
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_WITH_DPRINTF")
+
+  # libinotify uses c99 extension, so suppress this error
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-c99-extensions")
+endif()
+
 if(${CMAKE_CXX_COMPILER_ID} STREQUAL Clang)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=parentheses-equality")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-zero-length-array")
 endif()
 
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG")

--- a/cmake/03-libs.cmake
+++ b/cmake/03-libs.cmake
@@ -21,3 +21,8 @@ querylib(WITH_XRENDER "pkg-config" xcb-render libs dirs)
 querylib(WITH_XRM "pkg-config" xcb-xrm libs dirs)
 querylib(WITH_XSYNC "pkg-config" xcb-sync libs dirs)
 querylib(WITH_XCURSOR "pkg-config" xcb-cursor libs dirs)
+
+# FreeBSD Support
+if(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+  querylib(TRUE "pkg-config" libinotify libs dirs)
+endif()

--- a/include/adapters/alsa/generic.hpp
+++ b/include/adapters/alsa/generic.hpp
@@ -4,7 +4,11 @@
 #include <alsa/asoundlib.h>
 #else
 #include <assert.h>
+
+#ifndef __FreeBSD__
 #include <endian.h>
+#endif
+
 #include <errno.h>
 #include <fcntl.h>
 #include <stdarg.h>


### PR DESCRIPTION
Added support for FreeBSD. Uses libinotify wrapper for inotify calls. I also had to disable some compiler warnings as libinotify uses c99 extensions.

Fixes #239.