### PR TITLE
feat(script): %pid% token for tail commands

### DIFF
--- a/include/modules/script.hpp
+++ b/include/modules/script.hpp
@@ -29,6 +29,8 @@ namespace modules {
 
     unique_ptr<command> m_command;
 
+    bool m_tail;
+
     string m_exec;
     string m_exec_if;
 

--- a/src/modules/script.cpp
+++ b/src/modules/script.cpp
@@ -174,39 +174,20 @@ namespace modules {
     string cnt{to_string(m_counter)};
     string output{module::get_output()};
 
-    if (!m_actions[mousebtn::LEFT].empty()) {
-      m_builder->cmd(mousebtn::LEFT, string_util::replace_all(m_actions[mousebtn::LEFT], "%counter%", cnt));
+    for (auto btn : {mousebtn::LEFT, mousebtn::MIDDLE, mousebtn::RIGHT, mousebtn::SCROLL_UP, mousebtn::SCROLL_DOWN}) {
 
-      if(m_tail && m_command && m_command->is_running()) {
-        m_builder->cmd(mousebtn::LEFT, string_util::replace_all(m_actions[mousebtn::LEFT], "%pid%", std::to_string(m_command->get_pid())));
-      }
-    }
-    if (!m_actions[mousebtn::MIDDLE].empty()) {
-      m_builder->cmd(mousebtn::MIDDLE, string_util::replace_all(m_actions[mousebtn::MIDDLE], "%counter%", cnt));
+      auto action = m_actions[btn];
 
-      if(m_tail && m_command && m_command->is_running()) {
-        m_builder->cmd(mousebtn::MIDDLE, string_util::replace_all(m_actions[mousebtn::MIDDLE], "%pid%", std::to_string(m_command->get_pid())));
-      }
-    }
-    if (!m_actions[mousebtn::RIGHT].empty()) {
-      m_builder->cmd(mousebtn::RIGHT, string_util::replace_all(m_actions[mousebtn::RIGHT], "%counter%", cnt));
+      if (!action.empty()) {
+        m_builder->cmd(btn, string_util::replace_all(action, "%counter%", cnt));
 
-      if(m_tail && m_command && m_command->is_running()) {
-        m_builder->cmd(mousebtn::RIGHT, string_util::replace_all(m_actions[mousebtn::RIGHT], "%pid%", std::to_string(m_command->get_pid())));
-      }
-    }
-    if (!m_actions[mousebtn::SCROLL_UP].empty()) {
-      m_builder->cmd(mousebtn::SCROLL_UP, string_util::replace_all(m_actions[mousebtn::SCROLL_UP], "%counter%", cnt));
-
-      if(m_tail && m_command && m_command->is_running()) {
-        m_builder->cmd(mousebtn::SCROLL_UP, string_util::replace_all(m_actions[mousebtn::SCROLL_UP], "%pid%", std::to_string(m_command->get_pid())));
-      }
-    }
-    if (!m_actions[mousebtn::SCROLL_DOWN].empty()) {
-      m_builder->cmd( mousebtn::SCROLL_DOWN, string_util::replace_all(m_actions[mousebtn::SCROLL_DOWN], "%counter%", cnt));
-
-      if(m_tail && m_command && m_command->is_running()) {
-        m_builder->cmd(mousebtn::SCROLL_DOWN, string_util::replace_all(m_actions[mousebtn::SCROLL_DOWN], "%pid%", std::to_string(m_command->get_pid())));
+        /*
+         * The pid token is only for tailed commands.
+         * If the command is not specified or running, replacement is unnecessary as well
+         */
+        if(m_tail && m_command && m_command->is_running()) {
+          m_builder->cmd(btn, string_util::replace_all(action, "%pid%", to_string(m_command->get_pid())));
+        }
       }
     }
 

--- a/src/modules/script.cpp
+++ b/src/modules/script.cpp
@@ -13,9 +13,11 @@ namespace modules {
    */
   script_module::script_module(const bar_settings& bar, string name_)
       : module<script_module>(bar, move(name_)), m_handler([&]() -> function<chrono::duration<double>()> {
+
+        m_tail = m_conf.get(name(), "tail", false);
         // Handler for continuous tail commands {{{
 
-        if (m_conf.get(name(), "tail", false)) {
+        if (m_tail) {
           return [&] {
             if (!m_command || !m_command->is_running()) {
               string exec{string_util::replace_all(m_exec, "%counter%", to_string(++m_counter))};
@@ -174,19 +176,38 @@ namespace modules {
 
     if (!m_actions[mousebtn::LEFT].empty()) {
       m_builder->cmd(mousebtn::LEFT, string_util::replace_all(m_actions[mousebtn::LEFT], "%counter%", cnt));
+
+      if(m_tail && m_command && m_command->is_running()) {
+        m_builder->cmd(mousebtn::LEFT, string_util::replace_all(m_actions[mousebtn::LEFT], "%pid%", std::to_string(m_command->get_pid())));
+      }
     }
     if (!m_actions[mousebtn::MIDDLE].empty()) {
       m_builder->cmd(mousebtn::MIDDLE, string_util::replace_all(m_actions[mousebtn::MIDDLE], "%counter%", cnt));
+
+      if(m_tail && m_command && m_command->is_running()) {
+        m_builder->cmd(mousebtn::MIDDLE, string_util::replace_all(m_actions[mousebtn::MIDDLE], "%pid%", std::to_string(m_command->get_pid())));
+      }
     }
     if (!m_actions[mousebtn::RIGHT].empty()) {
       m_builder->cmd(mousebtn::RIGHT, string_util::replace_all(m_actions[mousebtn::RIGHT], "%counter%", cnt));
+
+      if(m_tail && m_command && m_command->is_running()) {
+        m_builder->cmd(mousebtn::RIGHT, string_util::replace_all(m_actions[mousebtn::RIGHT], "%pid%", std::to_string(m_command->get_pid())));
+      }
     }
     if (!m_actions[mousebtn::SCROLL_UP].empty()) {
       m_builder->cmd(mousebtn::SCROLL_UP, string_util::replace_all(m_actions[mousebtn::SCROLL_UP], "%counter%", cnt));
+
+      if(m_tail && m_command && m_command->is_running()) {
+        m_builder->cmd(mousebtn::SCROLL_UP, string_util::replace_all(m_actions[mousebtn::SCROLL_UP], "%pid%", std::to_string(m_command->get_pid())));
+      }
     }
     if (!m_actions[mousebtn::SCROLL_DOWN].empty()) {
-      m_builder->cmd(
-          mousebtn::SCROLL_DOWN, string_util::replace_all(m_actions[mousebtn::SCROLL_DOWN], "%counter%", cnt));
+      m_builder->cmd( mousebtn::SCROLL_DOWN, string_util::replace_all(m_actions[mousebtn::SCROLL_DOWN], "%counter%", cnt));
+
+      if(m_tail && m_command && m_command->is_running()) {
+        m_builder->cmd(mousebtn::SCROLL_DOWN, string_util::replace_all(m_actions[mousebtn::SCROLL_DOWN], "%pid%", std::to_string(m_command->get_pid())));
+      }
     }
 
     m_builder->append(output);


### PR DESCRIPTION
This can be used to send signals to the script running (e.g. SIGUSR1, etc) which
makes it easier to have an updatable state inside the script. With this, it is
for example possible to have a two-state date script:
```dosini
[module/date]
type = custom/script
exec = /path/to/date.sh
tail = true
click-left = bash -c "kill -SIGUSR1 %pid%"
```

`date.sh`:
```bash

t=0

toggle() {
    t=$(((t + 1) % 2))
}


trap "toggle" USR1

while true; do
    if [ $t -eq 0 ]; then
        date
    else
        date --rfc-3339=seconds
    fi
    sleep 1 &
    wait
done
```
Todo:
- [ ]  Add to wiki