### PR TITLE
feat(i3): Add workspace separator

### DIFF
--- a/doc/config.cmake
+++ b/doc/config.cmake
@@ -152,6 +152,10 @@ label-urgent = %index%
 label-urgent-background = ${module/bspwm.label-urgent-background}
 label-urgent-padding = ${module/bspwm.label-urgent-padding}
 
+; Separator in between workspaces
+; label-separator = |
+
+
 [module/mpd]
 type = internal/mpd
 format-online = <label-song>  <icon-prev> <icon-stop> <toggle> <icon-next>

--- a/include/modules/i3.hpp
+++ b/include/modules/i3.hpp
@@ -76,6 +76,11 @@ namespace modules {
     label_t m_modelabel;
     bool m_modeactive{false};
 
+    /**
+     * Separator that is inserted in between workspaces
+     */
+    label_t m_labelseparator;
+
     bool m_click{true};
     bool m_scroll{true};
     bool m_revscroll{true};

--- a/src/modules/i3.cpp
+++ b/src/modules/i3.cpp
@@ -52,6 +52,8 @@ namespace modules {
       m_modelabel = load_optional_label(m_conf, name(), "label-mode", "%mode%");
     }
 
+    m_labelseparator = load_optional_label(m_conf, name(), "label-separator", "");
+
     m_icons = factory_util::shared<iconset>();
     m_icons->add(DEFAULT_WS_ICON, factory_util::shared<label>(m_conf.get(name(), DEFAULT_WS_ICON, ""s)));
 
@@ -171,7 +173,19 @@ namespace modules {
         builder->cmd(mousebtn::SCROLL_UP, EVENT_SCROLL_UP);
       }
 
+      bool first = true;
       for (auto&& ws : m_workspaces) {
+        /*
+         * The separator should only be inserted in between the workspaces, so
+         * we insert it in front of all workspaces except the first one.
+         */
+        if(first) {
+          first = false;
+        }
+        else if (*m_labelseparator) {
+          builder->node(m_labelseparator);
+        }
+
         if (m_click) {
           builder->cmd(mousebtn::LEFT, string{EVENT_CLICK} + ws->name);
           builder->node(ws->label);


### PR DESCRIPTION
Puts a label-separator node between workspaces on the bar. Since the
separator uses a label it can be configured like any other label

To-Do after merge:

- [ ] Add to wiki