### PR TITLE
volume: Change all volume module references to alsa

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ A compiler with C++14 support ([clang-3.4+](http://llvm.org/releases/download.ht
 - xcb-util-cursor *required for the `cursor-click` and `cursor-scroll` settings*
 
 **Optional dependencies for extended module support:**
-- alsa-lib *required by `internal/volume`*
+- alsa-lib *required by `internal/alsa`*
 - libpulse *required by `internal/pulseaudio`*
 - jsoncpp *required by `internal/i3`*
 - libmpdclient *required by `internal/mpd`*

--- a/build.sh
+++ b/build.sh
@@ -40,7 +40,7 @@ function main
 
   read -r -p "$(msg "Include support for \"internal/i3\" (requires i3) ------------------- [Y/n]: ")" -n 1 p && echo
   [[ "${p^^}" != "Y" ]] && enable_i3="OFF"
-  read -r -p "$(msg "Include support for \"internal/volume\" (requires alsalib) ---------- [Y/n]: ")" -n 1 p && echo
+  read -r -p "$(msg "Include support for \"internal/alsa\" (requires alsalib) ---------- [Y/n]: ")" -n 1 p && echo
   [[ "${p^^}" != "Y" ]] && enable_alsa="OFF"
   read -r -p "$(msg "Include support for \"internal/pulseaudio\" (requires libpulse) ----- [Y/n]: ")" -n 1 p && echo
   [[ "${p^^}" != "Y" ]] && enable_pulseaudio="OFF"

--- a/contrib/polybar-git.aur/PKGBUILD
+++ b/contrib/polybar-git.aur/PKGBUILD
@@ -3,14 +3,14 @@
 _pkgname=polybar
 pkgname="${_pkgname}-git"
 pkgver=3.1.0
-pkgrel=1
+pkgrel=2
 pkgdesc="A fast and easy-to-use status bar"
 arch=("i686" "x86_64")
 url="https://github.com/jaagr/polybar"
 license=("MIT")
 depends=("cairo" "xcb-util-image" "xcb-util-wm" "xcb-util-xrm" "xcb-util-cursor")
-optdepends=("alsa-lib: volume module support"
-            "libpulse: pulseaudio module support"
+optdepends=("alsa-lib: alsa module support"
+            "pulseaudio: pulseaudio module support"
             "libmpdclient: mpd module support"
             "wireless_tools: network module support"
             "jsoncpp: i3 module support"

--- a/contrib/polybar.aur/PKGBUILD
+++ b/contrib/polybar.aur/PKGBUILD
@@ -8,7 +8,7 @@ arch=("i686" "x86_64")
 url="https://github.com/jaagr/polybar"
 license=("MIT")
 depends=("cairo" "xcb-util-image" "xcb-util-wm" "xcb-util-xrm" "xcb-util-cursor")
-optdepends=("alsa-lib: volume module support"
+optdepends=("alsa-lib: alsa module support"
             "libmpdclient: mpd module support"
             "wireless_tools: network module support"
             "jsoncpp: i3 module support"

--- a/doc/config.cmake
+++ b/doc/config.cmake
@@ -264,8 +264,8 @@ format-underline = #0a6cf5
 
 label = %date% %time%
 
-[module/volume]
-type = internal/volume
+[module/alsa]
+type = internal/alsa
 
 format-volume = <label-volume> <bar-volume>
 label-volume = VOL

--- a/include/modules/alsa.hpp
+++ b/include/modules/alsa.hpp
@@ -19,9 +19,9 @@ namespace modules {
   using mixer_t = shared_ptr<alsa::mixer>;
   using control_t = shared_ptr<alsa::control>;
 
-  class volume_module : public event_module<volume_module>, public input_handler {
+  class alsa_module : public event_module<alsa_module>, public input_handler {
    public:
-    explicit volume_module(const bar_settings&, string);
+    explicit alsa_module(const bar_settings&, string);
 
     void teardown();
     bool has_event();

--- a/include/modules/meta/factory.hpp
+++ b/include/modules/meta/factory.hpp
@@ -52,7 +52,7 @@ POLYBAR_NS
 using namespace modules;
 
 namespace {
-  module_interface* make_module(string&& name, const bar_settings& bar, string module_name) {
+  module_interface* make_module(string&& name, const bar_settings& bar, string module_name, const logger& m_log) {
     if (name == "internal/counter") {
       return new counter_module(bar, move(module_name));
     } else if (name == "internal/backlight") {
@@ -76,7 +76,8 @@ namespace {
     } else if (name == "internal/mpd") {
       return new mpd_module(bar, move(module_name));
     } else if (name == "internal/volume") {
-      throw application_error("internal/volume is deprecated, use internal/alsa instead");
+      m_log.warn("internal/volume is deprecated, use internal/alsa instead");
+      return new alsa_module(bar, move("internal/alsa"));
     } else if (name == "internal/alsa") {
       return new alsa_module(bar, move(module_name));
     } else if (name == "internal/pulseaudio") {

--- a/include/modules/meta/factory.hpp
+++ b/include/modules/meta/factory.hpp
@@ -76,6 +76,8 @@ namespace {
     } else if (name == "internal/mpd") {
       return new mpd_module(bar, move(module_name));
     } else if (name == "internal/volume") {
+      throw application_error("internal/volume is deprecated, use internal/alsa instead");
+    } else if (name == "internal/alsa") {
       return new volume_module(bar, move(module_name));
     } else if (name == "internal/pulseaudio") {
       return new pulseaudio_module(bar, move(module_name));

--- a/include/modules/meta/factory.hpp
+++ b/include/modules/meta/factory.hpp
@@ -32,7 +32,7 @@
 #include "modules/network.hpp"
 #endif
 #if ENABLE_ALSA
-#include "modules/volume.hpp"
+#include "modules/alsa.hpp"
 #endif
 #if ENABLE_PULSEAUDIO
 #include "modules/pulseaudio.hpp"
@@ -78,7 +78,7 @@ namespace {
     } else if (name == "internal/volume") {
       throw application_error("internal/volume is deprecated, use internal/alsa instead");
     } else if (name == "internal/alsa") {
-      return new volume_module(bar, move(module_name));
+      return new alsa_module(bar, move(module_name));
     } else if (name == "internal/pulseaudio") {
       return new pulseaudio_module(bar, move(module_name));
     } else if (name == "internal/network") {

--- a/include/modules/unsupported.hpp
+++ b/include/modules/unsupported.hpp
@@ -41,7 +41,7 @@ namespace modules {
   DEFINE_UNSUPPORTED_MODULE(network_module, "internal/network");
 #endif
 #if not ENABLE_ALSA
-  DEFINE_UNSUPPORTED_MODULE(volume_module, "internal/volume");
+  DEFINE_UNSUPPORTED_MODULE(alsa_module, "internal/alsa");
 #endif
 #if not ENABLE_PULSEAUDIO
   DEFINE_UNSUPPORTED_MODULE(pulseaudio_module, "internal/pulseaudio");

--- a/src/components/controller.cpp
+++ b/src/components/controller.cpp
@@ -103,7 +103,7 @@ controller::controller(connection& conn, signal_emitter& emitter, const logger& 
           throw application_error("Inter-process messaging needs to be enabled");
         }
 
-        m_modules[align].emplace_back(make_module(move(type), m_bar->settings(), module_name));
+        m_modules[align].emplace_back(make_module(move(type), m_bar->settings(), module_name, m_log));
         created_modules++;
       } catch (const runtime_error& err) {
         m_log.err("Disabling module \"%s\" (reason: %s)", module_name, err.what());

--- a/src/modules/alsa.cpp
+++ b/src/modules/alsa.cpp
@@ -1,4 +1,4 @@
-#include "modules/volume.hpp"
+#include "modules/alsa.hpp"
 #include "adapters/alsa/control.hpp"
 #include "adapters/alsa/generic.hpp"
 #include "adapters/alsa/mixer.hpp"
@@ -16,9 +16,9 @@ POLYBAR_NS
 using namespace alsa;
 
 namespace modules {
-  template class module<volume_module>;
+  template class module<alsa_module>;
 
-  volume_module::volume_module(const bar_settings& bar, string name_) : event_module<volume_module>(bar, move(name_)) {
+  alsa_module::alsa_module(const bar_settings& bar, string name_) : event_module<alsa_module>(bar, move(name_)) {
     // Load configuration values
     m_mapped = m_conf.get(name(), "mapped", m_mapped);
 
@@ -86,13 +86,13 @@ namespace modules {
     }
   }
 
-  void volume_module::teardown() {
+  void alsa_module::teardown() {
     m_mixer.clear();
     m_ctrl.clear();
     snd_config_update_free_global();
   }
 
-  bool volume_module::has_event() {
+  bool alsa_module::has_event() {
     // Poll for mixer and control events
     try {
       if (m_mixer[mixer::MASTER] && m_mixer[mixer::MASTER]->wait(25)) {
@@ -114,7 +114,7 @@ namespace modules {
     return false;
   }
 
-  bool volume_module::update() {
+  bool alsa_module::update() {
     // Consume pending events
     if (m_mixer[mixer::MASTER]) {
       m_mixer[mixer::MASTER]->process_events();
@@ -179,11 +179,11 @@ namespace modules {
     return true;
   }
 
-  string volume_module::get_format() const {
+  string alsa_module::get_format() const {
     return m_muted ? FORMAT_MUTED : FORMAT_VOLUME;
   }
 
-  string volume_module::get_output() {
+  string alsa_module::get_output() {
     // Get the module output early so that
     // the format prefix/suffix also gets wrapper
     // with the cmd handlers
@@ -200,7 +200,7 @@ namespace modules {
     return m_builder->flush();
   }
 
-  bool volume_module::build(builder* builder, const string& tag) const {
+  bool alsa_module::build(builder* builder, const string& tag) const {
     if (tag == TAG_BAR_VOLUME) {
       builder->node(m_bar_volume->output(m_volume));
     } else if (tag == TAG_RAMP_VOLUME && (!m_headphones || !*m_ramp_headphones)) {
@@ -217,7 +217,7 @@ namespace modules {
     return true;
   }
 
-  bool volume_module::input(string&& cmd) {
+  bool alsa_module::input(string&& cmd) {
     if (!m_handle_events) {
       return false;
     } else if (cmd.compare(0, 3, EVENT_PREFIX) != 0) {


### PR DESCRIPTION
Not exactly sure how we should deprecate a module name, because we don't have a function for that. If we used `log.warn()` we would have to pass `m_log` to `make_module()`. Right now it just throws an `application_error`.