### PR TITLE
fix(alsa): use correct name for deprecation

### DIFF
--- a/include/modules/meta/factory.hpp
+++ b/include/modules/meta/factory.hpp
@@ -77,7 +77,7 @@ namespace {
       return new mpd_module(bar, move(module_name));
     } else if (name == "internal/volume") {
       m_log.warn("internal/volume is deprecated, use internal/alsa instead");
-      return new alsa_module(bar, move("internal/alsa"));
+      return new alsa_module(bar, move(name));
     } else if (name == "internal/alsa") {
       return new alsa_module(bar, move(module_name));
     } else if (name == "internal/pulseaudio") {


### PR DESCRIPTION
Not sure why I changed the module name... it broke all module options because it tried to find `internal/alsa` when `internal/volume` was specified. Now the options should be properly detected.