### PR TITLE
fix(mpd): Check m_status before derefencing it

### DIFF
--- a/include/modules/mpd.hpp
+++ b/include/modules/mpd.hpp
@@ -64,6 +64,12 @@ namespace modules {
     static constexpr const char* EVENT_SEEK{"mpdseek"};
 
     unique_ptr<mpdconnection> m_mpd;
+
+    /*
+     * Stores the mpdstatus instance for the current connection
+     * m_status is not initialized if mpd is not connect, you always have to
+     * make sure that m_status is not NULL before dereferencing it
+     */
     unique_ptr<mpdstatus> m_status;
 
     string m_host{"127.0.0.1"};

--- a/src/modules/mpd.cpp
+++ b/src/modules/mpd.cpp
@@ -200,7 +200,7 @@ namespace modules {
       }
     }
 
-    if (m_status->match_state(mpdstate::PLAYING)) {
+    if (m_status && m_status->match_state(mpdstate::PLAYING)) {
       // Always update the status while playing
       m_status->update(-1, m_mpd.get());
     }


### PR DESCRIPTION
This bug was introduced in 645a3142a19747c252d24cc71414d40a8eb5f7dc

Fixes #979