### PR TITLE
fix(bspwm): remove monitor focus command

### DIFF
--- a/src/modules/bspwm.cpp
+++ b/src/modules/bspwm.cpp
@@ -493,14 +493,14 @@ namespace modules {
 
     if (m_pinworkspaces) {
       modifier = ".local";
-    }
-
-    for (const auto& mon : m_monitors) {
-      if (m_bar.monitor->match(mon->name, false) && !mon->focused) {
-        send_command("monitor -f " + mon->name, "Sending monitor focus command to ipc handler");
-        break;
+      for (const auto& mon : m_monitors) {
+        if (m_bar.monitor->match(mon->name, false) && !mon->focused) {
+          send_command("monitor -f " + mon->name, "Sending monitor focus command to ipc handler");
+          break;
+        }
       }
     }
+
 
     send_command("desktop -f " + scrolldir + modifier, "Sending desktop " + scrolldir + " command to ipc handler");
 


### PR DESCRIPTION
I *think* #981 is an issue, but I need someone else to confirm it (both the problem and the fix).

Fixes #981.