### PR TITLE
Fix battery module crashing

### DIFF
--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -82,7 +82,7 @@ namespace modules {
     });
 
     // Make consumption reader
-    m_consumption_reader = make_unique<consumption_reader>([this,&path_battery] {
+    m_consumption_reader = make_unique<consumption_reader>([this,path_battery] {
       float consumption;
 
       // if the rate we found was the current, calculate power (P = I*V)


### PR DESCRIPTION
`path_battery` goes out of scope, so the stack reference becomes garbage

Fixes #985