### PR TITLE
Add Source Mage package for polybar

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ If you are using **Debian**, polybar is available from the [GetDeb](http://www.g
 
 If you are using **Slackware**, polybar is available from the [SlackBuilds](https://slackbuilds.org/repository/14.2/desktop/polybar/) repository.
 
+If you are using **Source Mage GNU/Linux**, polybar spell is available in test grimoire and can be installed via `cast polybar`.
 
 ### Dependencies
 


### PR DESCRIPTION
Since we've recently [added](https://github.com/sourcemage/grimoire/commit/728bc1864077610f447ee960d55ac66ce9627fbe) polybar to our package base, it'd be good to have it the official support list.