### PR TITLE
Respect 'enable-scroll' setting for xworkspaces module

### DIFF
--- a/src/modules/xworkspaces.cpp
+++ b/src/modules/xworkspaces.cpp
@@ -264,8 +264,10 @@ namespace modules {
       output += module::get_output();
     }
 
-    m_builder->cmd(mousebtn::SCROLL_DOWN, string{EVENT_PREFIX} + string{EVENT_SCROLL_DOWN});
-    m_builder->cmd(mousebtn::SCROLL_UP, string{EVENT_PREFIX} + string{EVENT_SCROLL_UP});
+    if (m_scroll) {
+      m_builder->cmd(mousebtn::SCROLL_DOWN, string{EVENT_PREFIX} + string{EVENT_SCROLL_DOWN});
+      m_builder->cmd(mousebtn::SCROLL_UP, string{EVENT_PREFIX} + string{EVENT_SCROLL_UP});
+    }
 
     m_builder->append(output);
 


### PR DESCRIPTION
This is to fix `enable-scroll` setting being ignored for the xworkspaces module.