### PR TITLE
[WIP] fix(controller): Abort select call after 5 seconds

### DIFF
--- a/src/components/controller.cpp
+++ b/src/components/controller.cpp
@@ -290,7 +290,20 @@ void controller::read_events() {
     }
 
     // Check for errors
-    if (events == -1 || g_terminate || m_connection.connection_has_error()) {
+    if (events == -1)  {
+
+      /*
+       * The Interrupt errno is generated when polybar is stopped, so it
+       * shouldn't generate an error message
+       */
+      if (errno != EINTR) {
+        m_log.err("select failed in event loop: %s", strerror(errno));
+      }
+
+      break;
+    }
+
+    if (g_terminate || m_connection.connection_has_error()) {
       break;
     }
 


### PR DESCRIPTION
Without a timeout, the select call can possibly wait for an arbitrary
length of time. This helps detect these stalls (as reported in #939)

EDIT: Don't merge yet, I just noticed that a five second period without any event can also occur normally