### PR TITLE
fix(doc): GetDeb packages not Debian compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ If you are using **Void Linux**, you can install [polybar](https://github.com/vo
 
 If you are using **NixOS**, polybar is available in both the stable and unstable channels and can be installed with the command `nix-env -iA nixos.polybar`.
 
-If you are using **Debian**, polybar is available from the [GetDeb](http://www.getdeb.net/app/Polybar) repository.
+If you are using **Ubuntu**, polybar is available from the [GetDeb](http://www.getdeb.net/app/Polybar) repository.
 
 If you are using **Slackware**, polybar is available from the [SlackBuilds](https://slackbuilds.org/repository/14.2/desktop/polybar/) repository.
 


### PR DESCRIPTION
There is no Debian release in GetDeb and according to [1] packages
from Ubuntu repositories can break a Debian system.

Fixes #1000

[1]: https://wiki.debian.org/DontBreakDebian#Don.27t_make_a_FrankenDebian