### PR TITLE
xkeyboard: add icons for layouts and indicators

### DIFF
--- a/include/modules/xkeyboard.hpp
+++ b/include/modules/xkeyboard.hpp
@@ -21,6 +21,19 @@ namespace modules {
       : public static_module<xkeyboard_module>,
         public event_handler<evt::xkb_new_keyboard_notify, evt::xkb_state_notify, evt::xkb_indicator_state_notify>,
         public input_handler {
+   
+   enum class indicator_state {
+     NONE,
+     /**
+      * @brief Indicator is off
+      */
+     OFF,
+     /**
+      * @brief Indicator is on
+      */
+     ON
+   };
+
    public:
     explicit xkeyboard_module(const bar_settings& bar, string name_);
 
@@ -43,10 +56,10 @@ namespace modules {
     static constexpr const char* TAG_LABEL_INDICATOR{"<label-indicator>"};
     static constexpr const char* FORMAT_DEFAULT{"<label-layout> <label-indicator>"};
     static constexpr const char* DEFAULT_LAYOUT_ICON{"layout-icon-default"};
+    static constexpr const char* DEFAULT_INDICATOR_ICON{"indicator-icon-default"};
     
     static constexpr const char* EVENT_SWITCH{"xkeyboard/switch"};
-    
-    
+
     connection& m_connection;
     event_timer m_xkb_newkb_notify{};
     event_timer m_xkb_state_notify{};
@@ -55,10 +68,13 @@ namespace modules {
 
     label_t m_layout;
     label_t m_indicator;
+    map<indicator_state, label_t> m_indicatorstates;
     map<keyboard::indicator::type, label_t> m_indicators;
 
     vector<string> m_blacklist;
     iconset_t m_layout_icons;
+    iconset_t m_indicator_icons_on;
+    iconset_t m_indicator_icons_off;
   };
 }
 

--- a/include/modules/xkeyboard.hpp
+++ b/include/modules/xkeyboard.hpp
@@ -56,6 +56,7 @@ namespace modules {
     map<keyboard::indicator::type, label_t> m_indicators;
 
     vector<string> m_blacklist;
+    iconset_t m_layout_icons;
   };
 }
 

--- a/include/modules/xkeyboard.hpp
+++ b/include/modules/xkeyboard.hpp
@@ -42,9 +42,11 @@ namespace modules {
     static constexpr const char* TAG_LABEL_LAYOUT{"<label-layout>"};
     static constexpr const char* TAG_LABEL_INDICATOR{"<label-indicator>"};
     static constexpr const char* FORMAT_DEFAULT{"<label-layout> <label-indicator>"};
-
+    static constexpr const char* DEFAULT_LAYOUT_ICON{"layout-icon-default"};
+    
     static constexpr const char* EVENT_SWITCH{"xkeyboard/switch"};
-
+    
+    
     connection& m_connection;
     event_timer m_xkb_newkb_notify{};
     event_timer m_xkb_state_notify{};

--- a/include/x11/extensions/xkb.hpp
+++ b/include/x11/extensions/xkb.hpp
@@ -49,7 +49,7 @@ namespace evt {
 class keyboard {
  public:
   struct indicator {
-    enum class type { NONE = 0U, CAPS_LOCK, NUM_LOCK };
+    enum class type { NONE = 0U, CAPS_LOCK, NUM_LOCK, SCROLL_LOCK };
     xcb_atom_t atom{};
     unsigned char mask{0};
     string name{};

--- a/src/modules/xkeyboard.cpp
+++ b/src/modules/xkeyboard.cpp
@@ -6,7 +6,6 @@
 #include "x11/connection.hpp"
 
 #include "modules/meta/base.inl"
-#include "cairo/utils.hpp"
 
 POLYBAR_NS
 

--- a/src/modules/xkeyboard.cpp
+++ b/src/modules/xkeyboard.cpp
@@ -73,9 +73,9 @@ namespace modules {
       for (const auto& it : m_conf.get_list<string>(name(), "indicator-icon", {})) {
         auto icon_triple = string_util::split(it, ';');
         if (icon_triple.size() == 3) {
-          auto const indicator_str = string_util::lower(vec[0]);
-          m_indicator_icons_off->add(indicator_str, factory_util::shared<label>(vec[1]));
-          m_indicator_icons_on->add(indicator_str, factory_util::shared<label>(vec[2]));
+          auto const indicator_str = string_util::lower(icon_triple[0]);
+          m_indicator_icons_off->add(indicator_str, factory_util::shared<label>(icon_triple[1]));
+          m_indicator_icons_on->add(indicator_str, factory_util::shared<label>(icon_triple[2]));
         }
       }
     }

--- a/src/modules/xkeyboard.cpp
+++ b/src/modules/xkeyboard.cpp
@@ -6,6 +6,7 @@
 #include "x11/connection.hpp"
 
 #include "modules/meta/base.inl"
+#include "cairo/utils.hpp"
 
 POLYBAR_NS
 
@@ -22,6 +23,8 @@ namespace modules {
     
     // load layout icons
     m_layout_icons = factory_util::shared<iconset>();
+    m_layout_icons->add(DEFAULT_LAYOUT_ICON, factory_util::shared<label>(
+          m_conf.get(name(), DEFAULT_LAYOUT_ICON, ""s)));
 
     for(const auto& it : m_conf.get_list<string>(name(), "layout-icon", {})) {
       auto vec = string_util::split(it, ';');
@@ -59,12 +62,10 @@ namespace modules {
       m_layout->reset_tokens();
       m_layout->replace_token("%name%", m_keyboard->group_name(m_keyboard->current()));
       
-      auto current_layout = m_keyboard->layout_name(m_keyboard->current());
- 
-      if(m_layout_icons->has(current_layout)) {
-        current_layout = m_layout_icons->get(current_layout)->get();
-      } 
+      auto const current_layout = m_keyboard->layout_name(m_keyboard->current());
+      auto icon = m_layout_icons->get(current_layout, DEFAULT_LAYOUT_ICON);
 
+      m_layout->replace_token("%icon%", icon->get());
       m_layout->replace_token("%layout%", current_layout);
       m_layout->replace_token("%number%", to_string(m_keyboard->current()));
     }

--- a/src/x11/extensions/xkb.cpp
+++ b/src/x11/extensions/xkb.cpp
@@ -181,6 +181,8 @@ namespace xkb_util {
         type = keyboard::indicator::type::CAPS_LOCK;
       } else if (string_util::compare(name, "num lock")) {
         type = keyboard::indicator::type::NUM_LOCK;
+      } else if (string_util::compare(name, "scroll lock")) {
+        type = keyboard::indicator::type::SCROLL_LOCK;
       } else {
         continue;
       }


### PR DESCRIPTION
Added icon support for layouts and indicators in a similar way as it is done for i3 workspaces.

First of all a new `%icon%` token is available for the `<label-layout>` tag. Default icon (though not very useful) is specified with:

`layout-icon-default = some-icon`

and layout icons with  a `';'`-separated list of pairs

`layout-icon-0 = us;some-icon-1`
`layout-icon-1 = lt;some-icon-2`

The value on the lhs of `';'` will match `%layout%` token for a particular layout, eg. this list will work for layouts set up with

`$ setxkbmap -layout "us,lt" -option "grp:alt_shift_toggle"`

For indicators, `<label-indicator>` also gets `%icon%` token and two states: `'on'` and `'off'`. Default icons for indicators are specified with:

`indicator-icon-default = some-icon-1;some-icon-2`

where the first value is for the `'off'` state and the second is for the `'on'` state. Individual indicator icons can be specified with a list of `';'`-separated triples:

`indicator-icon-0 = caps lock;some-icon-1;some-icon-2`
`indicator-icon-1 = num lock;some-icon-3;some-icon-4`
`indicator-icon-2 = scroll lock;some-icon-5;some-icon-6`

Again, the first icon is for `'off'` state and the second one is for the `'on'` state.

`<label-indicator>` states can now be configured individually like this:

`label-indicator-on = %icon%`
`label-indicator-on-foreground = #0f0`
`...`

`label-indicator-off = %icon%`
`label-indicator-off-foreground = #f00`
`...`

If these states are not explicitly specified, `label-indicator-on` will inherit values from `label-indicator` and `label-indicator-off` will be empty so that existing user configs are not broken (who expect nothing to be shown when indicator is off). Otherwise values set for `label-indicator-*` are ignored (though the tag is itself is still named `<label-indicator>`).

Also `scroll lock` indicator was missing from the implementation even though it was mentioned in the wiki, so I added that. 

I've tested this with my old configs and a dozen or so other dotfiles i found on /r/unixporn and nothing breaks except maybe `scroll lock` indicator would now pop up if it was not blacklisted before (though every config I've seen have indicators disabled anyway).

Going forward I would also like to use a whitelist mode instead of a blacklist mode for two reasons:
1) New indicators (if they are added in the future) would not unexpectedly popup for users who don't have them blacklisted explicitly.
2) The order in which indicators are rendered depend on the order they are defined in `keyboard::indicator::type` `enum`. With a whitelist, we could render them in the order they appear in this list.

In case this gets merged there's an updated wiki page in my repo:
https://github.com/ozelis/polybar/wiki/xkeyboard







