### PR TITLE
logger: Enable trace logging by default

### DIFF
--- a/cmake/02-opts.cmake
+++ b/cmake/02-opts.cmake
@@ -42,9 +42,10 @@ option(WITH_XKB "xcb-xkb support" ON)
 option(WITH_XRM "xcb-xrm support" ON)
 option(WITH_XCURSOR "xcb-cursor support" ON)
 
+option(DEBUG_LOGGER "Trace logging" ON)
+
 if(CMAKE_BUILD_TYPE_UPPER MATCHES DEBUG)
-  option(DEBUG_LOGGER "Debug logging" ON)
-  option(DEBUG_LOGGER_VERBOSE "Debug logging (verbose)" OFF)
+  option(DEBUG_LOGGER_VERBOSE "Trace logging (verbose)" OFF)
   option(DEBUG_HINTS "Debug clickable areas" OFF)
   option(DEBUG_WHITESPACE "Debug whitespace" OFF)
   option(DEBUG_FONTCONFIG "Debug fontconfig" OFF)

--- a/cmake/05-summary.cmake
+++ b/cmake/05-summary.cmake
@@ -31,9 +31,11 @@ colored_option("   xcb-xkb" WITH_XKB)
 colored_option("   xcb-xrm" WITH_XRM)
 colored_option("   xcb-cursor" WITH_XCURSOR)
 
+message(STATUS " Log options:")
+colored_option("   Trace logging" DEBUG_LOGGER)
+
 if(CMAKE_BUILD_TYPE_UPPER MATCHES DEBUG)
   message(STATUS " Debug options:")
-  colored_option("   Trace logging" DEBUG_LOGGER)
   colored_option("   Trace logging (verbose)" DEBUG_LOGGER_VERBOSE)
   colored_option("   Draw clickable areas" DEBUG_HINTS)
   colored_option("   Print fc-match details" DEBUG_FONTCONFIG)


### PR DESCRIPTION
Often we may need information from the user that is only available if
-l trace is used which requires most users to recompile polybar in debug
mode.