### PR TITLE
Changed loglevel to info

### DIFF
--- a/src/components/bar.cpp
+++ b/src/components/bar.cpp
@@ -710,7 +710,7 @@ void bar::handle(const evt::button_press& evt) {
         return;
       }
     }
-    m_log.warn("No matching input area found (btn=%i)", static_cast<int>(m_buttonpress_btn));
+    m_log.info("No matching input area found (btn=%i)", static_cast<int>(m_buttonpress_btn));
   };
 
   const auto check_double = [&](string&& id, mousebtn&& btn) {


### PR DESCRIPTION
See this as a suggestion, i didn't want to create an issue for such a small fix.
> Changed loglevel for "No matching input area found" from warn to info

In my opinion it is irritating when polybar emits a warning when i click with a not defined button on an element. I didn't define that click handler, so everything should be fine