### PR TITLE
refactor(aur): Remove unused i3ipc-glib dependency

### DIFF
--- a/contrib/polybar-git.aur/PKGBUILD
+++ b/contrib/polybar-git.aur/PKGBUILD
@@ -14,7 +14,6 @@ optdepends=("alsa-lib: alsa module support"
             "libmpdclient: mpd module support"
             "wireless_tools: network module support"
             "jsoncpp: i3 module support"
-            "i3ipc-glib-git: i3 module support"
             "ttf-unifont: Font used in example config"
             "siji-git: Font used in example config"
             "curl: github module support")

--- a/contrib/polybar.aur/PKGBUILD
+++ b/contrib/polybar.aur/PKGBUILD
@@ -12,7 +12,6 @@ optdepends=("alsa-lib: alsa module support"
             "libmpdclient: mpd module support"
             "wireless_tools: network module support"
             "jsoncpp: i3 module support"
-            "i3ipc-glib-git: i3 module support"
             "ttf-unifont: Font used in example config"
             "siji-git: Font used in example config"
             "curl: github module support")


### PR DESCRIPTION
Polybar includes no header files from this library and doesn't use any
i3ipc_* functions