### PR TITLE
refactor(clang-tidy,format): apply fixes

### DIFF
--- a/include/adapters/alsa/control.hpp
+++ b/include/adapters/alsa/control.hpp
@@ -36,6 +36,6 @@ namespace alsa {
     snd_hctl_t* m_hctl{nullptr};
     snd_hctl_elem_t* m_elem{nullptr};
   };
-}
+}  // namespace alsa
 
 POLYBAR_NS_END

--- a/include/adapters/alsa/generic.hpp
+++ b/include/adapters/alsa/generic.hpp
@@ -7,11 +7,11 @@
 #include <endian.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <poll.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <poll.h>
 #include <sys/types.h>
 #include <unistd.h>
 
@@ -19,6 +19,7 @@
 #define __inline__ inline
 #endif
 
+// clang-format off
 #include <alsa/asoundef.h>
 #include <alsa/version.h>
 #include <alsa/global.h>
@@ -37,6 +38,7 @@
 #include <alsa/seqmid.h>
 #include <alsa/seq_midi_event.h>
 #endif
+// clang-format on
 
 #include "common.hpp"
 #include "settings.hpp"
@@ -56,6 +58,6 @@ namespace alsa {
       message += ": " + string{snd_error};
     throw T(message.c_str());
   }
-}
+}  // namespace alsa
 
 POLYBAR_NS_END

--- a/include/adapters/alsa/mixer.hpp
+++ b/include/adapters/alsa/mixer.hpp
@@ -45,6 +45,6 @@ namespace alsa {
     string m_name;
     string s_name;
   };
-}
+}  // namespace alsa
 
 POLYBAR_NS_END

--- a/include/adapters/mpd.hpp
+++ b/include/adapters/mpd.hpp
@@ -48,7 +48,7 @@ namespace mpd {
     struct mpd_song_deleter {
       void operator()(mpd_song* song);
     };
-  }
+  }  // namespace details
 
   using mpd_connection_t = unique_ptr<mpd_connection, details::mpd_connection_deleter>;
   using mpd_status_t = unique_ptr<mpd_status, details::mpd_status_deleter>;
@@ -177,6 +177,6 @@ namespace mpd {
   };
 
   // }}}
-}
+}  // namespace mpd
 
 POLYBAR_NS_END

--- a/include/adapters/net.hpp
+++ b/include/adapters/net.hpp
@@ -12,8 +12,8 @@
 #endif
 
 #include "common.hpp"
-#include "settings.hpp"
 #include "errors.hpp"
+#include "settings.hpp"
 #include "utils/math.hpp"
 
 POLYBAR_NS
@@ -126,6 +126,6 @@ namespace net {
 
   using wireless_t = unique_ptr<wireless_network>;
   using wired_t = unique_ptr<wired_network>;
-}
+}  // namespace net
 
 POLYBAR_NS_END

--- a/include/adapters/pulseaudio.hpp
+++ b/include/adapters/pulseaudio.hpp
@@ -4,8 +4,8 @@
 #include <queue>
 
 #include "common.hpp"
-#include "settings.hpp"
 #include "errors.hpp"
+#include "settings.hpp"
 
 #include "utils/math.hpp"
 // fwd
@@ -25,55 +25,55 @@ class pulseaudio {
   enum class evtype { NEW = 0, CHANGE, REMOVE };
   using queue = std::queue<evtype>;
 
-  public:
-    explicit pulseaudio(const logger& logger, string&& sink_name);
-    ~pulseaudio();
+ public:
+  explicit pulseaudio(const logger& logger, string&& sink_name);
+  ~pulseaudio();
 
-    pulseaudio(const pulseaudio& o) = delete;
-    pulseaudio& operator=(const pulseaudio& o) = delete;
+  pulseaudio(const pulseaudio& o) = delete;
+  pulseaudio& operator=(const pulseaudio& o) = delete;
 
-    const string& get_name();
+  const string& get_name();
 
-    bool wait();
-    int process_events();
+  bool wait();
+  int process_events();
 
-    int get_volume();
-    void set_volume(float percentage);
-    void inc_volume(int delta_perc);
-    void set_mute(bool mode);
-    void toggle_mute();
-    bool is_muted();
+  int get_volume();
+  void set_volume(float percentage);
+  void inc_volume(int delta_perc);
+  void set_mute(bool mode);
+  void toggle_mute();
+  bool is_muted();
 
-  private:
-    void update_volume(pa_operation *o);
-    static void check_mute_callback(pa_context *context, const pa_sink_info *info, int eol, void *userdata);
-    static void get_sink_volume_callback(pa_context *context, const pa_sink_info *info, int is_last, void *userdata);
-    static void subscribe_callback(pa_context* context, pa_subscription_event_type_t t, uint32_t idx, void* userdata);
-    static void simple_callback(pa_context *context, int success, void *userdata);
-    static void get_default_sink_callback(pa_context *context, const pa_server_info *info, void *userdata);
-    static void sink_info_callback(pa_context *context, const pa_sink_info *info, int eol, void *userdata);
-    static void context_state_callback(pa_context *context, void *userdata);
+ private:
+  void update_volume(pa_operation* o);
+  static void check_mute_callback(pa_context* context, const pa_sink_info* info, int eol, void* userdata);
+  static void get_sink_volume_callback(pa_context* context, const pa_sink_info* info, int is_last, void* userdata);
+  static void subscribe_callback(pa_context* context, pa_subscription_event_type_t t, uint32_t idx, void* userdata);
+  static void simple_callback(pa_context* context, int success, void* userdata);
+  static void get_default_sink_callback(pa_context* context, const pa_server_info* info, void* userdata);
+  static void sink_info_callback(pa_context* context, const pa_sink_info* info, int eol, void* userdata);
+  static void context_state_callback(pa_context* context, void* userdata);
 
-    inline void wait_loop(pa_operation *op, pa_threaded_mainloop *loop);
+  inline void wait_loop(pa_operation* op, pa_threaded_mainloop* loop);
 
-    const logger& m_log;
+  const logger& m_log;
 
-    // used for temporary callback results
-    int success{0};
-    pa_cvolume cv;
-    bool muted{false};
-    // default sink name
-    string def_s_name;
+  // used for temporary callback results
+  int success{0};
+  pa_cvolume cv;
+  bool muted{false};
+  // default sink name
+  string def_s_name;
 
-    pa_context* m_context{nullptr};
-    pa_threaded_mainloop* m_mainloop{nullptr};
+  pa_context* m_context{nullptr};
+  pa_threaded_mainloop* m_mainloop{nullptr};
 
-    queue m_events;
+  queue m_events;
 
-    // specified sink name
-    string spec_s_name;
-    string s_name;
-    uint32_t m_index{0};
+  // specified sink name
+  string spec_s_name;
+  string s_name;
+  uint32_t m_index{0};
 };
 
 POLYBAR_NS_END

--- a/include/cairo/context.hpp
+++ b/include/cairo/context.hpp
@@ -353,6 +353,6 @@ namespace cairo {
     std::deque<pair<double, double>> m_points;
     int m_activegroups{0};
   };
-}
+}  // namespace cairo
 
 POLYBAR_NS_END

--- a/include/cairo/font.hpp
+++ b/include/cairo/font.hpp
@@ -55,7 +55,8 @@ namespace cairo {
    */
   class font_fc : public font {
    public:
-    explicit font_fc(cairo_t* cairo, FcPattern* pattern, double offset, double dpi_x, double dpi_y) : font(cairo, offset), m_pattern(pattern) {
+    explicit font_fc(cairo_t* cairo, FcPattern* pattern, double offset, double dpi_x, double dpi_y)
+        : font(cairo, offset), m_pattern(pattern) {
       cairo_matrix_t fm;
       cairo_matrix_t ctm;
       cairo_matrix_init_scale(&fm, size(dpi_x), size(dpi_y));
@@ -274,6 +275,6 @@ namespace cairo {
 
     return make_shared<font_fc>(cairo, match, offset, dpi_x, dpi_y);
   }
-}
+}  // namespace cairo
 
 POLYBAR_NS_END

--- a/include/cairo/fwd.hpp
+++ b/include/cairo/fwd.hpp
@@ -10,6 +10,6 @@ namespace cairo {
   class xcb_surface;
   class font;
   class font_fc;
-}
+}  // namespace cairo
 
 POLYBAR_NS_END

--- a/include/cairo/surface.hpp
+++ b/include/cairo/surface.hpp
@@ -71,6 +71,6 @@ namespace cairo {
       cairo_xcb_surface_set_drawable(m_s, d, w, h);
     }
   };
-}
+}  // namespace cairo
 
 POLYBAR_NS_END

--- a/include/cairo/types.hpp
+++ b/include/cairo/types.hpp
@@ -61,9 +61,9 @@ namespace cairo {
     unsigned int bg;
     cairo_operator_t bg_operator;
     rect bg_rect;
-    double *x_advance;
-    double *y_advance;
+    double* x_advance;
+    double* y_advance;
   };
-}
+}  // namespace cairo
 
 POLYBAR_NS_END

--- a/include/cairo/utils.hpp
+++ b/include/cairo/utils.hpp
@@ -64,7 +64,7 @@ namespace cairo {
      * @brief Convert a UCS-4 codepoint to a utf-8 encoded string
      */
     size_t ucs4_to_utf8(char* utf8, unsigned int ucs);
-  }
-}
+  }  // namespace utils
+}  // namespace cairo
 
 POLYBAR_NS_END

--- a/include/common.hpp
+++ b/include/common.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
+#include <functional>
 #include <memory>
 #include <string>
 #include <vector>
-#include <functional>
 
 #include "settings.hpp"
 
@@ -23,20 +23,20 @@
 
 POLYBAR_NS
 
-using std::string;
-using std::size_t;
-using std::move;
-using std::forward;
-using std::pair;
-using std::function;
-using std::shared_ptr;
-using std::unique_ptr;
-using std::make_unique;
-using std::make_shared;
-using std::make_pair;
 using std::array;
-using std::vector;
+using std::forward;
+using std::function;
+using std::make_pair;
+using std::make_shared;
+using std::make_unique;
+using std::move;
+using std::pair;
+using std::shared_ptr;
+using std::size_t;
+using std::string;
 using std::to_string;
+using std::unique_ptr;
+using std::vector;
 
 using namespace std::string_literals;
 

--- a/include/components/bar.hpp
+++ b/include/components/bar.hpp
@@ -30,9 +30,10 @@ class bar : public xpp::event::sink<evt::button_press, evt::expose, evt::propert
             public signal_receiver<SIGN_PRIORITY_BAR, signals::eventqueue::start, signals::ui::tick,
                 signals::ui::shade_window, signals::ui::unshade_window, signals::ui::dim_window
 #if WITH_XCURSOR
-                , signals::ui::cursor_change
+                ,
+                signals::ui::cursor_change
 #endif
-		> {
+                > {
  public:
   using make_type = unique_ptr<bar>;
   static make_type make(bool only_initialize_values = false);

--- a/include/components/builder.hpp
+++ b/include/components/builder.hpp
@@ -15,7 +15,7 @@ namespace drawtypes {
   using label_t = shared_ptr<label>;
   using icon = label;
   using icon_t = label_t;
-}
+}  // namespace drawtypes
 using namespace drawtypes;
 
 class builder {

--- a/include/components/command_line.hpp
+++ b/include/components/command_line.hpp
@@ -73,6 +73,6 @@ namespace command_line {
   };
 
   // }}}
-}
+}  // namespace command_line
 
 POLYBAR_NS_END

--- a/include/components/controller.hpp
+++ b/include/components/controller.hpp
@@ -4,10 +4,10 @@
 #include <thread>
 
 #include "common.hpp"
-#include "settings.hpp"
 #include "events/signal_fwd.hpp"
 #include "events/signal_receiver.hpp"
 #include "events/types.hpp"
+#include "settings.hpp"
 #include "utils/file.hpp"
 #include "x11/types.hpp"
 
@@ -27,14 +27,15 @@ class signal_emitter;
 namespace modules {
   struct module_interface;
   class input_handler;
-}
+}  // namespace modules
 using module_t = unique_ptr<modules::module_interface>;
 using modulemap_t = std::map<alignment, vector<module_t>>;
 
 // }}}
 
-class controller : public signal_receiver<SIGN_PRIORITY_CONTROLLER, signals::eventqueue::exit_terminate, signals::eventqueue::exit_reload,
-                       signals::eventqueue::notify_change, signals::eventqueue::notify_forcechange, signals::eventqueue::check_state, signals::ipc::action,
+class controller : public signal_receiver<SIGN_PRIORITY_CONTROLLER, signals::eventqueue::exit_terminate,
+                       signals::eventqueue::exit_reload, signals::eventqueue::notify_change,
+                       signals::eventqueue::notify_forcechange, signals::eventqueue::check_state, signals::ipc::action,
                        signals::ipc::command, signals::ipc::hook, signals::ui::ready, signals::ui::button_press> {
  public:
   using make_type = unique_ptr<controller>;

--- a/include/components/renderer.hpp
+++ b/include/components/renderer.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <bitset>
 #include <cairo/cairo.h>
+#include <bitset>
 
 #include "cairo/fwd.hpp"
 #include "common.hpp"
@@ -119,7 +119,7 @@ class renderer
   cairo_operator_t m_comp_ul{CAIRO_OPERATOR_OVER};
   cairo_operator_t m_comp_border{CAIRO_OPERATOR_OVER};
 
-  alignment m_align;
+  alignment m_align{};
   std::bitset<3> m_attr;
   int m_font{0};
   unsigned int m_bg{0U};

--- a/include/components/screen.hpp
+++ b/include/components/screen.hpp
@@ -45,7 +45,9 @@ class screen : public xpp::event::sink<evt::randr_screen_change_notify> {
   xcb_window_t m_proxy{XCB_NONE};
 
   vector<monitor_t> m_monitors;
-  struct size m_size {0U, 0U};
+  struct size m_size {
+    0U, 0U
+  };
   bool m_sigraised{false};
 };
 

--- a/include/debug.hpp
+++ b/include/debug.hpp
@@ -46,6 +46,6 @@ namespace debug_util {
   void memory_usage(const T& object) noexcept {
     printf("memory usage: %lub\n", sizeof(object));
   }
-}
+}  // namespace debug_util
 
 POLYBAR_NS_END

--- a/include/drawtypes/animation.hpp
+++ b/include/drawtypes/animation.hpp
@@ -40,6 +40,6 @@ namespace drawtypes {
 
   animation_t load_animation(
       const config& conf, const string& section, string name = "animation", bool required = true);
-}
+}  // namespace drawtypes
 
 POLYBAR_NS_END

--- a/include/drawtypes/iconset.hpp
+++ b/include/drawtypes/iconset.hpp
@@ -21,6 +21,6 @@ namespace drawtypes {
   };
 
   using iconset_t = shared_ptr<iconset>;
-}
+}  // namespace drawtypes
 
 POLYBAR_NS_END

--- a/include/drawtypes/label.hpp
+++ b/include/drawtypes/label.hpp
@@ -35,15 +35,15 @@ namespace drawtypes {
     string m_underline{};
     string m_overline{};
     int m_font{0};
-    side_values m_padding{0U,0U};
-    side_values m_margin{0U,0U};
+    side_values m_padding{0U, 0U};
+    side_values m_margin{0U, 0U};
     size_t m_maxlen{0_z};
     bool m_ellipsis{true};
 
     explicit label(string text, int font) : m_font(font), m_text(text), m_tokenized(m_text) {}
     explicit label(string text, string foreground = ""s, string background = ""s, string underline = ""s,
-        string overline = ""s, int font = 0, struct side_values padding = {0U,0U}, struct side_values margin = {0U,0U},
-        size_t maxlen = 0_z, bool ellipsis = true, vector<token>&& tokens = {})
+        string overline = ""s, int font = 0, struct side_values padding = {0U, 0U},
+        struct side_values margin = {0U, 0U}, size_t maxlen = 0_z, bool ellipsis = true, vector<token>&& tokens = {})
         : m_foreground(foreground)
         , m_background(background)
         , m_underline(underline)
@@ -64,7 +64,7 @@ namespace drawtypes {
     void reset_tokens();
     void reset_tokens(const string& tokenized);
     bool has_token(const string& token) const;
-    void replace_token(const string& token, string replacement);
+    void replace_token(const string& token, const string& replacement);
     void replace_defined_values(const label_t& label);
     void copy_undefined(const label_t& label);
 
@@ -79,6 +79,6 @@ namespace drawtypes {
 
   icon_t load_icon(const config& conf, string section, string name, bool required = true, string def = ""s);
   icon_t load_optional_icon(const config& conf, string section, string name, string def = ""s);
-}
+}  // namespace drawtypes
 
 POLYBAR_NS_END

--- a/include/drawtypes/progressbar.hpp
+++ b/include/drawtypes/progressbar.hpp
@@ -46,6 +46,6 @@ namespace drawtypes {
   using progressbar_t = shared_ptr<progressbar>;
 
   progressbar_t load_progressbar(const bar_settings& bar, const config& conf, const string& section, string name);
-}
+}  // namespace drawtypes
 
 POLYBAR_NS_END

--- a/include/drawtypes/ramp.hpp
+++ b/include/drawtypes/ramp.hpp
@@ -25,6 +25,6 @@ namespace drawtypes {
   using ramp_t = shared_ptr<ramp>;
 
   ramp_t load_ramp(const config& conf, const string& section, string name, bool required = true);
-}
+}  // namespace drawtypes
 
 POLYBAR_NS_END

--- a/include/errors.hpp
+++ b/include/errors.hpp
@@ -7,9 +7,9 @@
 
 POLYBAR_NS
 
-using std::strerror;
 using std::exception;
 using std::runtime_error;
+using std::strerror;
 
 class application_error : public runtime_error {
  public:

--- a/include/events/signal.hpp
+++ b/include/events/signal.hpp
@@ -54,7 +54,7 @@ namespace signals {
      private:
       void* m_ptr;
     };
-  }
+  }  // namespace detail
 
   namespace eventqueue {
     struct start : public detail::base_signal<start> {
@@ -75,7 +75,7 @@ namespace signals {
     struct check_state : public detail::base_signal<check_state> {
       using base_type::base_type;
     };
-  }
+  }  // namespace eventqueue
 
   namespace ipc {
     struct command : public detail::value_signal<command, string> {
@@ -87,7 +87,7 @@ namespace signals {
     struct action : public detail::value_signal<action, string> {
       using base_type::base_type;
     };
-  }
+  }  // namespace ipc
 
   namespace ui {
     struct ready : public detail::base_signal<ready> {
@@ -120,13 +120,13 @@ namespace signals {
     struct request_snapshot : public detail::value_signal<request_snapshot, string> {
       using base_type::base_type;
     };
-  }
+  }  // namespace ui
 
   namespace ui_tray {
     struct mapped_clients : public detail::value_signal<mapped_clients, unsigned int> {
       using base_type::base_type;
     };
-  }
+  }  // namespace ui_tray
 
   namespace parser {
     struct change_background : public detail::value_signal<change_background, unsigned int> {
@@ -171,7 +171,7 @@ namespace signals {
     struct text : public detail::value_signal<text, string> {
       using base_type::base_type;
     };
-  }
-}
+  }  // namespace parser
+}  // namespace signals
 
 POLYBAR_NS_END

--- a/include/events/signal_fwd.hpp
+++ b/include/events/signal_fwd.hpp
@@ -21,12 +21,12 @@ namespace signals {
     struct notify_change;
     struct notify_forcechange;
     struct check_state;
-  }
+  }  // namespace eventqueue
   namespace ipc {
     struct command;
     struct hook;
     struct action;
-  }
+  }  // namespace ipc
   namespace ui {
     struct ready;
     struct changed;
@@ -38,7 +38,7 @@ namespace signals {
     struct shade_window;
     struct unshade_window;
     struct request_snapshot;
-  }
+  }  // namespace ui
   namespace ui_tray {
     struct mapped_clients;
   }
@@ -57,7 +57,7 @@ namespace signals {
     struct action_begin;
     struct action_end;
     struct text;
-  }
-}
+  }  // namespace parser
+}  // namespace signals
 
 POLYBAR_NS_END

--- a/include/events/signal_receiver.hpp
+++ b/include/events/signal_receiver.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <map>
-#include <unordered_map>
 #include <typeindex>
 #include <typeinfo>
+#include <unordered_map>
 
 #include "common.hpp"
 

--- a/include/events/types.hpp
+++ b/include/events/types.hpp
@@ -54,6 +54,6 @@ namespace {
   inline event make_check_evt() {
     return event{static_cast<int>(event_type::CHECK)};
   }
-}
+}  // namespace
 
 POLYBAR_NS_END

--- a/include/modules/alsa.hpp
+++ b/include/modules/alsa.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "settings.hpp"
 #include "modules/meta/event_module.hpp"
 #include "modules/meta/input_handler.hpp"
+#include "settings.hpp"
 
 POLYBAR_NS
 
@@ -10,7 +10,7 @@ POLYBAR_NS
 namespace alsa {
   class mixer;
   class control;
-}
+}  // namespace alsa
 
 namespace modules {
   enum class mixer { NONE = 0, MASTER, SPEAKER, HEADPHONE };
@@ -62,6 +62,6 @@ namespace modules {
     atomic<bool> m_headphones{false};
     atomic<int> m_volume{0};
   };
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/include/modules/backlight.hpp
+++ b/include/modules/backlight.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "components/config.hpp"
-#include "settings.hpp"
 #include "modules/meta/inotify_module.hpp"
+#include "settings.hpp"
 
 POLYBAR_NS
 
@@ -38,6 +38,6 @@ namespace modules {
 
     int m_percentage = 0;
   };
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/include/modules/battery.hpp
+++ b/include/modules/battery.hpp
@@ -103,6 +103,6 @@ namespace modules {
     chrono::system_clock::time_point m_lastpoll;
     thread m_subthread;
   };
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/include/modules/bspwm.hpp
+++ b/include/modules/bspwm.hpp
@@ -91,6 +91,6 @@ namespace modules {
     // used while formatting output
     size_t m_index{0U};
   };
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/include/modules/counter.hpp
+++ b/include/modules/counter.hpp
@@ -17,6 +17,6 @@ namespace modules {
 
     int m_counter{0};
   };
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/include/modules/cpu.hpp
+++ b/include/modules/cpu.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "settings.hpp"
 #include "modules/meta/timer_module.hpp"
+#include "settings.hpp"
 
 POLYBAR_NS
 
@@ -44,6 +44,6 @@ namespace modules {
     float m_total = 0;
     vector<float> m_load;
   };
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/include/modules/date.hpp
+++ b/include/modules/date.hpp
@@ -3,9 +3,9 @@
 #include "modules/meta/input_handler.hpp"
 #include "modules/meta/timer_module.hpp"
 
-#include <iostream>
-#include <iomanip>
 #include <ctime>
+#include <iomanip>
+#include <iostream>
 
 POLYBAR_NS
 
@@ -42,6 +42,6 @@ namespace modules {
 
     std::atomic<bool> m_toggled{false};
   };
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/include/modules/fs.hpp
+++ b/include/modules/fs.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "components/config.hpp"
-#include "settings.hpp"
 #include "modules/meta/timer_module.hpp"
+#include "settings.hpp"
 
 POLYBAR_NS
 
@@ -66,6 +66,6 @@ namespace modules {
     // used while formatting output
     size_t m_index{0_z};
   };
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/include/modules/github.hpp
+++ b/include/modules/github.hpp
@@ -28,6 +28,6 @@ namespace modules {
     unique_ptr<http_downloader> m_http{};
     bool m_empty_notifications{false};
   };
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/include/modules/i3.hpp
+++ b/include/modules/i3.hpp
@@ -92,6 +92,6 @@ namespace modules {
 
     unique_ptr<i3_util::connection_t> m_ipc;
   };
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/include/modules/ipc.hpp
+++ b/include/modules/ipc.hpp
@@ -41,6 +41,6 @@ namespace modules {
     string m_output;
     size_t m_initial;
   };
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/include/modules/memory.hpp
+++ b/include/modules/memory.hpp
@@ -32,6 +32,6 @@ namespace modules {
     int m_perc_swap_used{0};
     int m_perc_swap_free{0};
   };
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/include/modules/menu.hpp
+++ b/include/modules/menu.hpp
@@ -43,6 +43,6 @@ namespace modules {
 
     std::atomic<int> m_level{-1};
   };
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/include/modules/meta/base.hpp
+++ b/include/modules/meta/base.hpp
@@ -41,7 +41,7 @@ namespace drawtypes {
   using icon_t = label_t;
   class iconset;
   using iconset_t = shared_ptr<iconset>;
-}
+}  // namespace drawtypes
 
 class builder;
 class config;
@@ -163,6 +163,6 @@ namespace modules {
   };
 
   // }}}
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/include/modules/meta/event_handler.hpp
+++ b/include/modules/meta/event_handler.hpp
@@ -28,6 +28,6 @@ namespace modules {
       conn.detach_sink(this, SINK_PRIORITY_MODULE);
     }
   };
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/include/modules/meta/event_module.hpp
+++ b/include/modules/meta/event_module.hpp
@@ -40,6 +40,6 @@ namespace modules {
       }
     }
   };
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/include/modules/meta/factory.hpp
+++ b/include/modules/meta/factory.hpp
@@ -43,7 +43,8 @@
 #if ENABLE_XKEYBOARD
 #include "modules/xkeyboard.hpp"
 #endif
-#if not(ENABLE_I3 && ENABLE_MPD && ENABLE_NETWORK && ENABLE_ALSA && ENABLE_PULSEAUDIO && ENABLE_CURL && ENABLE_XKEYBOARD)
+#if not( \
+    ENABLE_I3 && ENABLE_MPD && ENABLE_NETWORK && ENABLE_ALSA && ENABLE_PULSEAUDIO && ENABLE_CURL && ENABLE_XKEYBOARD)
 #include "modules/unsupported.hpp"
 #endif
 
@@ -110,6 +111,6 @@ namespace {
       throw application_error("Unknown module: " + name);
     }
   }
-}
+}  // namespace
 
 POLYBAR_NS_END

--- a/include/modules/meta/inotify_module.hpp
+++ b/include/modules/meta/inotify_module.hpp
@@ -88,6 +88,6 @@ namespace modules {
    private:
     map<string, int> m_watchlist;
   };
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/include/modules/meta/input_handler.hpp
+++ b/include/modules/meta/input_handler.hpp
@@ -10,6 +10,6 @@ namespace modules {
     virtual ~input_handler() {}
     virtual bool input(string&& cmd) = 0;
   };
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/include/modules/meta/static_module.hpp
+++ b/include/modules/meta/static_module.hpp
@@ -22,6 +22,6 @@ namespace modules {
       return true;
     }
   };
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/include/modules/meta/timer_module.hpp
+++ b/include/modules/meta/timer_module.hpp
@@ -44,6 +44,6 @@ namespace modules {
    protected:
     interval_t m_interval{1.0};
   };
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/include/modules/mpd.hpp
+++ b/include/modules/mpd.hpp
@@ -2,10 +2,10 @@
 
 #include <chrono>
 
-#include "utils/env.hpp"
 #include "adapters/mpd.hpp"
 #include "modules/meta/event_module.hpp"
 #include "modules/meta/input_handler.hpp"
+#include "utils/env.hpp"
 
 POLYBAR_NS
 
@@ -95,6 +95,6 @@ namespace modules {
     string m_toggle_on_color;
     string m_toggle_off_color;
   };
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/include/modules/network.hpp
+++ b/include/modules/network.hpp
@@ -53,6 +53,6 @@ namespace modules {
     bool m_accumulate{false};
     bool m_unknown_up{false};
   };
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/include/modules/pulseaudio.hpp
+++ b/include/modules/pulseaudio.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "settings.hpp"
 #include "modules/meta/event_module.hpp"
 #include "modules/meta/input_handler.hpp"
+#include "settings.hpp"
 
 POLYBAR_NS
 
@@ -50,6 +50,6 @@ namespace modules {
     atomic<bool> m_muted{false};
     atomic<int> m_volume{0};
   };
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/include/modules/script.hpp
+++ b/include/modules/script.hpp
@@ -44,6 +44,6 @@ namespace modules {
 
     bool m_stopping{false};
   };
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/include/modules/systray.hpp
+++ b/include/modules/systray.hpp
@@ -1,8 +1,8 @@
 #if DEBUG
 #pragma once
 
-#include "modules/meta/static_module.hpp"
 #include "modules/meta/input_handler.hpp"
+#include "modules/meta/static_module.hpp"
 
 POLYBAR_NS
 
@@ -34,7 +34,7 @@ namespace modules {
 
     bool m_hidden{false};
   };
-}
+}  // namespace modules
 
 POLYBAR_NS_END
 #endif

--- a/include/modules/temperature.hpp
+++ b/include/modules/temperature.hpp
@@ -2,8 +2,8 @@
 
 #include <istream>
 
-#include "settings.hpp"
 #include "modules/meta/timer_module.hpp"
+#include "settings.hpp"
 
 POLYBAR_NS
 
@@ -36,6 +36,6 @@ namespace modules {
     // Whether or not to show units with the %temperature-X% tokens
     bool m_units{true};
   };
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/include/modules/text.hpp
+++ b/include/modules/text.hpp
@@ -13,6 +13,6 @@ namespace modules {
     string get_format() const;
     string get_output();
   };
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/include/modules/unsupported.hpp
+++ b/include/modules/unsupported.hpp
@@ -52,6 +52,6 @@ namespace modules {
 #if not ENABLE_XKEYBOARD
   DEFINE_UNSUPPORTED_MODULE(xkeyboard_module, "internal/xkeyboard");
 #endif
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/include/modules/xbacklight.hpp
+++ b/include/modules/xbacklight.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
 #include "components/config.hpp"
-#include "settings.hpp"
 #include "modules/meta/event_handler.hpp"
 #include "modules/meta/input_handler.hpp"
 #include "modules/meta/static_module.hpp"
+#include "settings.hpp"
 #include "x11/extensions/randr.hpp"
 
 POLYBAR_NS
@@ -58,6 +58,6 @@ namespace modules {
     bool m_scroll{true};
     std::atomic<int> m_percentage{0};
   };
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/include/modules/xkeyboard.hpp
+++ b/include/modules/xkeyboard.hpp
@@ -57,6 +57,6 @@ namespace modules {
 
     vector<string> m_blacklist;
   };
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/include/modules/xwindow.hpp
+++ b/include/modules/xwindow.hpp
@@ -45,6 +45,6 @@ namespace modules {
     unique_ptr<active_window> m_active;
     label_t m_label;
   };
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/include/modules/xworkspaces.hpp
+++ b/include/modules/xworkspaces.hpp
@@ -104,6 +104,6 @@ namespace modules {
 
     event_timer m_timer{0L, 25L};
   };
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/include/utils/bspwm.hpp
+++ b/include/utils/bspwm.hpp
@@ -32,6 +32,6 @@ namespace bspwm_util {
   payload_t make_payload(const string& cmd);
   connection_t make_connection();
   connection_t make_subscriber();
-}
+}  // namespace bspwm_util
 
 POLYBAR_NS_END

--- a/include/utils/color.hpp
+++ b/include/utils/color.hpp
@@ -112,7 +112,7 @@ namespace color_util {
 
     return hex;
   }
-}
+}  // namespace color_util
 
 struct rgb {
   double r;

--- a/include/utils/command.hpp
+++ b/include/utils/command.hpp
@@ -79,6 +79,6 @@ namespace command_util {
   unique_ptr<command> make_command(Args&&... args) {
     return factory_util::unique<command>(logger::make(), forward<Args>(args)...);
   }
-}
+}  // namespace command_util
 
 POLYBAR_NS_END

--- a/include/utils/concurrency.hpp
+++ b/include/utils/concurrency.hpp
@@ -11,7 +11,7 @@
 
 POLYBAR_NS
 
-namespace chrono =std::chrono;
+namespace chrono = std::chrono;
 using namespace std::chrono_literals;
 namespace this_thread = std::this_thread;
 

--- a/include/utils/env.hpp
+++ b/include/utils/env.hpp
@@ -7,6 +7,6 @@ POLYBAR_NS
 namespace env_util {
   bool has(const string& var);
   string get(const string& var, string fallback = "");
-}
+}  // namespace env_util
 
 POLYBAR_NS_END

--- a/include/utils/factory.hpp
+++ b/include/utils/factory.hpp
@@ -20,7 +20,7 @@ namespace factory_util {
         }
       }
     };
-  }
+  }  // namespace detail
 
   extern detail::null_deleter null_deleter;
   extern detail::fd_deleter fd_deleter;
@@ -40,6 +40,6 @@ namespace factory_util {
     static shared_ptr<T> instance{make_shared<T>(forward<Deps>(deps)...)};
     return instance;
   }
-}
+}  // namespace factory_util
 
 POLYBAR_NS_END

--- a/include/utils/file.hpp
+++ b/include/utils/file.hpp
@@ -112,6 +112,6 @@ namespace file_util {
   decltype(auto) make_file_descriptor(Args&&... args) {
     return factory_util::unique<file_descriptor>(forward<Args>(args)...);
   }
-}
+}  // namespace file_util
 
 POLYBAR_NS_END

--- a/include/utils/http.hpp
+++ b/include/utils/http.hpp
@@ -25,6 +25,6 @@ namespace http_util {
   decltype(auto) make_downloader(Args&&... args) {
     return factory_util::unique<http_downloader>(forward<Args>(args)...);
   }
-}
+}  // namespace http_util
 
 POLYBAR_NS_END

--- a/include/utils/i3.hpp
+++ b/include/utils/i3.hpp
@@ -20,7 +20,7 @@ namespace i3_util {
 
   vector<xcb_window_t> root_windows(connection& conn, const string& output_name = "");
   bool restack_to_root(connection& conn, const xcb_window_t win);
-}
+}  // namespace i3_util
 
 namespace {
   inline bool operator==(i3_util::workspace_t& a, i3_util::workspace_t& b) {
@@ -29,6 +29,6 @@ namespace {
   inline bool operator!=(i3_util::workspace_t& a, i3_util::workspace_t& b) {
     return !(a == b);
   }
-}
+}  // namespace
 
 POLYBAR_NS_END

--- a/include/utils/inotify.hpp
+++ b/include/utils/inotify.hpp
@@ -42,6 +42,6 @@ namespace inotify_util {
   decltype(auto) make_watch(Args&&... args) {
     return factory_util::unique<inotify_watch>(forward<Args>(args)...);
   }
-}
+}  // namespace inotify_util
 
 POLYBAR_NS_END

--- a/include/utils/io.hpp
+++ b/include/utils/io.hpp
@@ -22,6 +22,6 @@ namespace io_util {
 
   void set_block(int fd);
   void set_nonblock(int fd);
-}
+}  // namespace io_util
 
 POLYBAR_NS_END

--- a/include/utils/math.hpp
+++ b/include/utils/math.hpp
@@ -91,6 +91,6 @@ namespace math_util {
   inline int ceil(double value, int step = 1) {
     return static_cast<int>((value * 10 + step * 10 - 1) / (step * 10)) * step;
   }
-}
+}  // namespace math_util
 
 POLYBAR_NS_END

--- a/include/utils/memory.hpp
+++ b/include/utils/memory.hpp
@@ -25,6 +25,6 @@ namespace memory_util {
   inline auto countof(T& p) {
     return sizeof(p) / sizeof(p[0]);
   }
-}
+}  // namespace memory_util
 
 POLYBAR_NS_END

--- a/include/utils/process.hpp
+++ b/include/utils/process.hpp
@@ -19,6 +19,6 @@ namespace process_util {
   pid_t wait_for_completion_nohang();
 
   bool notify_childprocess();
-}
+}  // namespace process_util
 
 POLYBAR_NS_END

--- a/include/utils/scope.hpp
+++ b/include/utils/scope.hpp
@@ -39,6 +39,6 @@ namespace scope_util {
   decltype(auto) make_exit_handler(Fn&& fn, Args&&... args) {
     return factory_util::unique<on_exit<Args...>>(forward<Fn>(fn), forward<Args>(args)...);
   }
-}
+}  // namespace scope_util
 
 POLYBAR_NS_END

--- a/include/utils/socket.hpp
+++ b/include/utils/socket.hpp
@@ -43,6 +43,6 @@ namespace socket_util {
   auto make_unix_connection = [](string&& path) -> unique_ptr<unix_connection> {
     return factory_util::unique<unix_connection>(forward<string>(path));
   };
-}
+}  // namespace socket_util
 
 POLYBAR_NS_END

--- a/include/utils/string.hpp
+++ b/include/utils/string.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <sstream>
 #include <cstring>
+#include <sstream>
 
 #include "common.hpp"
 
@@ -27,7 +27,7 @@ namespace {
       a.erase(a.size() - b.size());
     }
   }
-}
+}  // namespace
 
 class sstream {
  public:
@@ -93,9 +93,9 @@ namespace string_util {
   string floating_point(double value, size_t precision, bool fixed = false, const string& locale = "");
   string filesize_mb(unsigned long long kbytes, size_t precision = 0, const string& locale = "");
   string filesize_gb(unsigned long long kbytes, size_t precision = 0, const string& locale = "");
-  string filesize(unsigned long long kbytes, size_t precision = 0, bool fixed = false, const string& locale = "");
+  string filesize(unsigned long long bytes, size_t precision = 0, bool fixed = false, const string& locale = "");
 
   hash_type hash(const string& src);
-}
+}  // namespace string_util
 
 POLYBAR_NS_END

--- a/include/utils/throttle.hpp
+++ b/include/utils/throttle.hpp
@@ -25,7 +25,7 @@ namespace throttle_util {
     struct wait_patiently_by_the_door {
       bool operator()(queue& q, limit l, timewindow);
     };
-  }
+  }  // namespace strategy
 
   /**
    * Throttle events within a set window of time
@@ -87,6 +87,6 @@ namespace throttle_util {
   throttle_t make_throttler(Args&&... args) {
     return factory_util::unique<event_throttler>(forward<Args>(args)...);
   }
-}
+}  // namespace throttle_util
 
 POLYBAR_NS_END

--- a/include/utils/time.hpp
+++ b/include/utils/time.hpp
@@ -18,6 +18,6 @@ namespace time_util {
     auto finish = clock_t::now();
     return chrono::duration_cast<Duration>(finish - start).count();
   }
-}
+}  // namespace time_util
 
 POLYBAR_NS_END

--- a/include/x11/connection.hpp
+++ b/include/x11/connection.hpp
@@ -93,7 +93,7 @@ namespace detail {
       dispatcher(error);
     }
   };
-}
+}  // namespace detail
 
 class connection : public detail::connection_base<connection&, XPP_EXTENSION_LIST> {
  public:

--- a/include/x11/cursor.hpp
+++ b/include/x11/cursor.hpp
@@ -9,19 +9,21 @@
 #include <xcb/xcb_cursor.h>
 
 #include "common.hpp"
-#include "x11/connection.hpp"
 #include "utils/string.hpp"
+#include "x11/connection.hpp"
 
 POLYBAR_NS
 
 namespace cursor_util {
   static const map<string, vector<string>> cursors = {
-    {"pointer", {"pointing_hand", "pointer", "hand", "hand1", "hand2", "e29285e634086352946a0e7090d73106", "9d800788f1b08800ae810202380a0822"}},
-    {"default", {"left_ptr", "arrow", "dnd-none", "op_left_arrow"}},
-    {"ns-resize", {"size_ver", "sb_v_double_arrow", "v_double_arrow", "n-resize", "s-resize", "col-resize", "top_side", "bottom_side", "base_arrow_up", "base_arrow_down", "based_arrow_down", "based_arrow_up", "00008160000006810000408080010102"}}
-  };
-  bool valid(string name);
-  bool set_cursor(xcb_connection_t *c, xcb_screen_t *screen, xcb_window_t w, string name);
-}
+      {"pointer", {"pointing_hand", "pointer", "hand", "hand1", "hand2", "e29285e634086352946a0e7090d73106",
+                      "9d800788f1b08800ae810202380a0822"}},
+      {"default", {"left_ptr", "arrow", "dnd-none", "op_left_arrow"}},
+      {"ns-resize", {"size_ver", "sb_v_double_arrow", "v_double_arrow", "n-resize", "s-resize", "col-resize",
+                        "top_side", "bottom_side", "base_arrow_up", "base_arrow_down", "based_arrow_down",
+                        "based_arrow_up", "00008160000006810000408080010102"}}};
+  bool valid(const string& name);
+  bool set_cursor(xcb_connection_t* c, xcb_screen_t* screen, xcb_window_t w, const string& name);
+}  // namespace cursor_util
 
 POLYBAR_NS_END

--- a/include/x11/ewmh.hpp
+++ b/include/x11/ewmh.hpp
@@ -41,6 +41,6 @@ namespace ewmh_util {
   void set_wm_window_opacity(xcb_window_t win, unsigned long int values);
 
   vector<xcb_window_t> get_client_list(int screen = 0);
-}
+}  // namespace ewmh_util
 
 POLYBAR_NS_END

--- a/include/x11/extensions/randr.hpp
+++ b/include/x11/extensions/randr.hpp
@@ -19,7 +19,7 @@ struct position;
 namespace evt {
   using randr_notify = xpp::randr::event::notify<connection&>;
   using randr_screen_change_notify = xpp::randr::event::screen_change_notify<connection&>;
-}
+}  // namespace evt
 
 struct backlight_values {
   unsigned int atom{0};
@@ -48,11 +48,13 @@ namespace randr_util {
 
   bool check_monitor_support();
 
-  monitor_t make_monitor(xcb_randr_output_t randr, string name, unsigned short int w, unsigned short int h, short int x, short int y);
-  vector<monitor_t> get_monitors(connection& conn, xcb_window_t root, bool connected_only = false, bool realloc = false);
+  monitor_t make_monitor(
+      xcb_randr_output_t randr, string name, unsigned short int w, unsigned short int h, short int x, short int y);
+  vector<monitor_t> get_monitors(
+      connection& conn, xcb_window_t root, bool connected_only = false, bool realloc = false);
 
   void get_backlight_range(connection& conn, const monitor_t& mon, backlight_values& dst);
   void get_backlight_value(connection& conn, const monitor_t& mon, backlight_values& dst);
-}
+}  // namespace randr_util
 
 POLYBAR_NS_END

--- a/include/x11/extensions/xkb.hpp
+++ b/include/x11/extensions/xkb.hpp
@@ -44,7 +44,7 @@ namespace evt {
   using xkb_action_message = xpp::xkb::event::action_message<connection&>;
   using xkb_access_x_notify = xpp::xkb::event::access_x_notify<connection&>;
   using xkb_extension_device_notify = xpp::xkb::event::extension_device_notify<connection&>;
-}
+}  // namespace evt
 
 class keyboard {
  public:
@@ -62,12 +62,14 @@ class keyboard {
   };
 
   explicit keyboard(vector<layout>&& layouts_, map<indicator::type, indicator>&& indicators_, unsigned char group)
-      : layouts(forward<decltype(layouts)>(layouts_)), indicators(forward<decltype(indicators)>(indicators_)), current_group(group) {}
+      : layouts(forward<decltype(layouts)>(layouts_))
+      , indicators(forward<decltype(indicators)>(indicators_))
+      , current_group(group) {}
 
   const indicator& get(const indicator::type& i) const;
   void set(unsigned int state);
   bool on(const indicator::type&) const;
-  void current(unsigned char  group);
+  void current(unsigned char group);
   unsigned char current() const;
   const string group_name(size_t index = 0) const;
   const string layout_name(size_t index = 0) const;
@@ -90,6 +92,6 @@ namespace xkb_util {
   vector<keyboard::layout> get_layouts(connection& conn, xcb_xkb_device_spec_t device);
   map<keyboard::indicator::type, keyboard::indicator> get_indicators(connection& conn, xcb_xkb_device_spec_t device);
   string parse_layout_symbol(string&& name);
-}
+}  // namespace xkb_util
 
 POLYBAR_NS_END

--- a/include/x11/icccm.hpp
+++ b/include/x11/icccm.hpp
@@ -13,6 +13,6 @@ namespace icccm_util {
   void set_wm_name(xcb_connection_t* c, xcb_window_t w, const char* wmname, size_t l, const char* wmclass, size_t l2);
   void set_wm_protocols(xcb_connection_t* c, xcb_window_t w, vector<xcb_atom_t> flags);
   bool get_wm_urgency(xcb_connection_t* c, xcb_window_t w);
-}
+}  // namespace icccm_util
 
 POLYBAR_NS_END

--- a/include/x11/registry.hpp
+++ b/include/x11/registry.hpp
@@ -9,7 +9,7 @@ namespace xpp {
     template <typename Connection, typename... Extensions>
     class registry;
   }
-}
+}  // namespace xpp
 
 POLYBAR_NS
 

--- a/include/x11/types.hpp
+++ b/include/x11/types.hpp
@@ -23,7 +23,7 @@ namespace xpp {
     template <class Event, class... Events>
     class sink;
   }
-}
+}  // namespace xpp
 
 POLYBAR_NS
 
@@ -79,6 +79,6 @@ namespace evt {
   using selection_clear = xpp::x::event::selection_clear<connection&>;
   using selection_notify = xpp::x::event::selection_notify<connection&>;
   using selection_request = xpp::x::event::selection_request<connection&>;
-}
+}  // namespace evt
 
 POLYBAR_NS_END

--- a/include/x11/xembed.hpp
+++ b/include/x11/xembed.hpp
@@ -39,6 +39,6 @@ namespace xembed {
   void notify_focused(connection& conn, xcb_window_t win, long focus_type);
   void notify_unfocused(connection& conn, xcb_window_t win);
   void unembed(connection& conn, xcb_window_t win, xcb_window_t root);
-}
+}  // namespace xembed
 
 POLYBAR_NS_END

--- a/src/adapters/alsa/control.cpp
+++ b/src/adapters/alsa/control.cpp
@@ -116,6 +116,6 @@ namespace alsa {
   void control::process_events() {
     wait(0);
   }
-}
+}  // namespace alsa
 
 POLYBAR_NS_END

--- a/src/adapters/alsa/mixer.cpp
+++ b/src/adapters/alsa/mixer.cpp
@@ -12,8 +12,7 @@ namespace alsa {
   /**
    * Construct mixer object
    */
-  mixer::mixer(string&& mixer_selem_name, string&& soundcard_name)
-      : m_name(forward<string>(mixer_selem_name)), s_name(soundcard_name) {
+  mixer::mixer(string&& mixer_selem_name, string&& soundcard_name) : m_name(mixer_selem_name), s_name(soundcard_name) {
     int err = 0;
 
     if ((err = snd_mixer_open(&m_mixer, 1)) == -1) {
@@ -227,6 +226,6 @@ namespace alsa {
     }
     return !state;
   }
-}
+}  // namespace alsa
 
 POLYBAR_NS_END

--- a/src/adapters/mpd.cpp
+++ b/src/adapters/mpd.cpp
@@ -35,20 +35,18 @@ namespace mpd {
     switch (mpd_connection_get_error(conn)) {
       case MPD_ERROR_SUCCESS:
         return;
-      case MPD_ERROR_SERVER:
-        {
-          err_msg = mpd_connection_get_error_message(conn);
-          enum mpd_server_error server_err = mpd_connection_get_server_error(conn);
-          mpd_connection_clear_error(conn);
-          throw server_error(err_msg, server_err);
-        }
-      default:
-        {
-          err_msg = mpd_connection_get_error_message(conn);
-          enum mpd_error err = mpd_connection_get_error(conn);
-          mpd_connection_clear_error(conn);
-          throw client_error(err_msg, err);
-        }
+      case MPD_ERROR_SERVER: {
+        err_msg = mpd_connection_get_error_message(conn);
+        enum mpd_server_error server_err = mpd_connection_get_server_error(conn);
+        mpd_connection_clear_error(conn);
+        throw server_error(err_msg, server_err);
+      }
+      default: {
+        err_msg = mpd_connection_get_error_message(conn);
+        enum mpd_error err = mpd_connection_get_error(conn);
+        mpd_connection_clear_error(conn);
+        throw client_error(err_msg, err);
+      }
     }
   }
 
@@ -68,7 +66,7 @@ namespace mpd {
     void mpd_song_deleter::operator()(mpd_song* song) {
       mpd_song_free(song);
     }
-  }
+  }  // namespace details
 
   // }}}
   // class: mpdsong {{{
@@ -474,6 +472,6 @@ namespace mpd {
   }
 
   // }}}
-}
+}  // namespace mpd
 
 POLYBAR_NS_END

--- a/src/adapters/net.cpp
+++ b/src/adapters/net.cpp
@@ -395,6 +395,6 @@ namespace net {
   }
 
   // }}}
-}
+}  // namespace net
 
 POLYBAR_NS_END

--- a/src/cairo/utils.cpp
+++ b/src/cairo/utils.cpp
@@ -170,7 +170,7 @@ namespace cairo {
         return 0;
       }
     }
-  }
-}
+  }  // namespace utils
+}  // namespace cairo
 
 POLYBAR_NS_END

--- a/src/components/bar.cpp
+++ b/src/components/bar.cpp
@@ -613,18 +613,22 @@ void bar::handle(const evt::motion_notify& evt) {
   m_log.trace("bar: Detected motion: %i at pos(%i, %i)", evt->detail, evt->event_x, evt->event_y);
 #if WITH_XCURSOR
   m_motion_pos = evt->event_x;
-  // scroll cursor is less important than click cursor, so we shouldn't return until we are sure there is no click action
+  // scroll cursor is less important than click cursor, so we shouldn't return until we are sure there is no click
+  // action
   bool found_scroll = false;
   const auto find_click_area = [&](const action& action) {
-    if (!m_opts.cursor_click.empty() && !(action.button == mousebtn::SCROLL_UP || action.button == mousebtn::SCROLL_DOWN || action.button == mousebtn::NONE)) {
+    if (!m_opts.cursor_click.empty() &&
+        !(action.button == mousebtn::SCROLL_UP || action.button == mousebtn::SCROLL_DOWN ||
+            action.button == mousebtn::NONE)) {
       if (!string_util::compare(m_opts.cursor, m_opts.cursor_click)) {
         m_opts.cursor = m_opts.cursor_click;
         m_sig.emit(cursor_change{string{m_opts.cursor}});
       }
       return true;
-    } else if (!m_opts.cursor_scroll.empty() && (action.button == mousebtn::SCROLL_UP || action.button == mousebtn::SCROLL_DOWN)) {
+    } else if (!m_opts.cursor_scroll.empty() &&
+               (action.button == mousebtn::SCROLL_UP || action.button == mousebtn::SCROLL_DOWN)) {
       if (!found_scroll) {
-          found_scroll = true;
+        found_scroll = true;
       }
     }
     return false;
@@ -633,11 +637,12 @@ void bar::handle(const evt::motion_notify& evt) {
   for (auto&& action : m_renderer->actions()) {
     if (action.test(m_motion_pos)) {
       m_log.trace("Found matching input area");
-      if(find_click_area(action))
+      if (find_click_area(action)) {
         return;
+      }
     }
   }
-  if(found_scroll) {
+  if (found_scroll) {
     if (!string_util::compare(m_opts.cursor, m_opts.cursor_scroll)) {
       m_opts.cursor = m_opts.cursor_scroll;
       m_sig.emit(cursor_change{string{m_opts.cursor}});
@@ -647,11 +652,12 @@ void bar::handle(const evt::motion_notify& evt) {
   for (auto&& action : m_opts.actions) {
     if (!action.command.empty()) {
       m_log.trace("Found matching fallback handler");
-      if(find_click_area(action))
+      if (find_click_area(action)) {
         return;
+      }
     }
   }
-  if(found_scroll) {
+  if (found_scroll) {
     if (!string_util::compare(m_opts.cursor, m_opts.cursor_scroll)) {
       m_opts.cursor = m_opts.cursor_scroll;
       m_sig.emit(cursor_change{string{m_opts.cursor}});
@@ -691,7 +697,7 @@ void bar::handle(const evt::button_press& evt) {
   const auto deferred_fn = [&](size_t) {
     /*
      * Iterate over all defined actions in reverse order until matching action is found
-     * To properly handle nested actions we iterate in reverse because nested actions are added later than their 
+     * To properly handle nested actions we iterate in reverse because nested actions are added later than their
      * surrounding action block
      */
     auto actions = m_renderer->actions();
@@ -788,7 +794,7 @@ bool bar::on(const signals::eventqueue::start&) {
   if (m_opts.dimvalue != 1.0) {
     m_connection.ensure_event_mask(m_opts.window, XCB_EVENT_MASK_ENTER_WINDOW | XCB_EVENT_MASK_LEAVE_WINDOW);
   }
-  if (!m_opts.cursor_click.empty() || !m_opts.cursor_scroll.empty() ) {
+  if (!m_opts.cursor_click.empty() || !m_opts.cursor_scroll.empty()) {
     m_connection.ensure_event_mask(m_opts.window, XCB_EVENT_MASK_POINTER_MOTION);
   }
 
@@ -931,7 +937,7 @@ bool bar::on(const signals::ui::dim_window& sig) {
 
 #if WITH_XCURSOR
 bool bar::on(const signals::ui::cursor_change& sig) {
-  if(!cursor_util::set_cursor(m_connection, m_connection.screen(), m_opts.window, sig.cast())) {
+  if (!cursor_util::set_cursor(m_connection, m_connection.screen(), m_opts.window, sig.cast())) {
     m_log.warn("Failed to create cursor context");
   }
   m_connection.flush();

--- a/src/components/builder.cpp
+++ b/src/components/builder.cpp
@@ -525,7 +525,7 @@ void builder::cmd(mousebtn index, string action, bool condition) {
  */
 void builder::cmd(mousebtn index, string action, const label_t& label) {
   if (label && *label) {
-    cmd(index, action, true);
+    cmd(index, move(action), true);
     node(label);
     tag_close(syntaxtag::A);
   }

--- a/src/components/command_line.cpp
+++ b/src/components/command_line.cpp
@@ -199,6 +199,6 @@ namespace command_line {
       throw argument_error("Unrecognized option " + input);
     }
   }
-}
+}  // namespace command_line
 
 POLYBAR_NS_END

--- a/src/components/config.cpp
+++ b/src/components/config.cpp
@@ -166,7 +166,7 @@ void config::parse_file() {
     // Initialize the xresource manage if there are any xrdb refs
     // present in the configuration
     if (!m_xrm && value.find("${xrdb") != string::npos) {
-      m_xrm.reset(new xresource_manager{connection::make()});
+      m_xrm = make_unique<xresource_manager>(connection::make());
     }
 #endif
 

--- a/src/components/controller.cpp
+++ b/src/components/controller.cpp
@@ -275,8 +275,7 @@ void controller::read_events() {
     int events = select(maxfd + 1, &readfds, nullptr, nullptr, nullptr);
 
     // Check for errors
-    if (events == -1)  {
-
+    if (events == -1) {
       /*
        * The Interrupt errno is generated when polybar is stopped, so it
        * shouldn't generate an error message
@@ -312,7 +311,8 @@ void controller::read_events() {
         // file to a different location (and subsequently deleting it).
         //
         // We need to re-attach the watch to the new file in this case.
-        fds.erase(std::remove_if(fds.begin(), fds.end(), [fd_confwatch](int fd) { return fd == fd_confwatch; }), fds.end());
+        fds.erase(
+            std::remove_if(fds.begin(), fds.end(), [fd_confwatch](int fd) { return fd == fd_confwatch; }), fds.end());
         m_confwatch = inotify_util::make_watch(m_confwatch->path());
         m_confwatch->attach(IN_MODIFY | IN_IGNORED);
         fds.emplace_back((fd_confwatch = m_confwatch->get_file_descriptor()));

--- a/src/components/renderer.cpp
+++ b/src/components/renderer.cpp
@@ -413,7 +413,7 @@ double renderer::block_x(alignment a) const {
        * So we can just subtract the tray_width = m_rect.x - border_left from the base_pos to correct for the tray being
        * placed on the left
        */
-      if(m_rect.x > border_left) {
+      if (m_rect.x > border_left) {
         base_pos -= m_rect.x - border_left;
       }
 

--- a/src/drawtypes/animation.cpp
+++ b/src/drawtypes/animation.cpp
@@ -64,6 +64,6 @@ namespace drawtypes {
 
     return factory_util::shared<animation>(move(vec), framerate);
   }
-}
+}  // namespace drawtypes
 
 POLYBAR_NS_END

--- a/src/drawtypes/iconset.cpp
+++ b/src/drawtypes/iconset.cpp
@@ -32,6 +32,6 @@ namespace drawtypes {
   iconset::operator bool() {
     return !m_icons.empty();
   }
-}
+}  // namespace drawtypes
 
 POLYBAR_NS_END

--- a/src/drawtypes/label.cpp
+++ b/src/drawtypes/label.cpp
@@ -41,7 +41,7 @@ namespace drawtypes {
     return m_tokenized.find(token) != string::npos;
   }
 
-  void label::replace_token(const string& token, string replacement) {
+  void label::replace_token(const string& token, const string& replacement) {
     if (!has_token(token)) {
       return;
     }
@@ -256,6 +256,6 @@ namespace drawtypes {
   icon_t load_optional_icon(const config& conf, string section, string name, string def) {
     return load_icon(conf, move(section), move(name), false, move(def));
   }
-}
+}  // namespace drawtypes
 
 POLYBAR_NS_END

--- a/src/drawtypes/progressbar.cpp
+++ b/src/drawtypes/progressbar.cpp
@@ -136,6 +136,6 @@ namespace drawtypes {
 
     return pbar;
   }
-}
+}  // namespace drawtypes
 
 POLYBAR_NS_END

--- a/src/drawtypes/ramp.cpp
+++ b/src/drawtypes/ramp.cpp
@@ -48,6 +48,6 @@ namespace drawtypes {
 
     return factory_util::shared<drawtypes::ramp>(move(vec));
   }
-}
+}  // namespace drawtypes
 
 POLYBAR_NS_END

--- a/src/modules/alsa.cpp
+++ b/src/modules/alsa.cpp
@@ -272,6 +272,6 @@ namespace modules {
 
     return true;
   }
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/src/modules/backlight.cpp
+++ b/src/modules/backlight.cpp
@@ -79,6 +79,6 @@ namespace modules {
     }
     return true;
   }
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -91,8 +91,8 @@ namespace modules {
         unsigned long current{std::strtoul(file_util::contents(m_frate).c_str(), nullptr, 10)};
         unsigned long voltage{std::strtoul(file_util::contents(m_fvoltage).c_str(), nullptr, 10)};
 
-        consumption = ((voltage / 1000.0) * (current /  1000.0)) / 1e6;
-      // if it was power, just use as is
+        consumption = ((voltage / 1000.0) * (current / 1000.0)) / 1e6;
+        // if it was power, just use as is
       } else {
         unsigned long power{std::strtoul(file_util::contents(m_frate).c_str(), nullptr, 10)};
 
@@ -100,7 +100,7 @@ namespace modules {
       }
 
       // convert to string with 2 decimmal places
-      string rtn(16, '\0'); // 16 should be plenty big. Cant see it needing more than 6/7..
+      string rtn(16, '\0');  // 16 should be plenty big. Cant see it needing more than 6/7..
       auto written = std::snprintf(&rtn[0], rtn.size(), "%.2f", consumption);
       rtn.resize(written);
 
@@ -298,8 +298,8 @@ namespace modules {
   }
 
   /**
-  * Get the current power consumption
-  */
+   * Get the current power consumption
+   */
   string battery_module::current_consumption() {
     return read(*m_consumption_reader);
   }
@@ -350,6 +350,6 @@ namespace modules {
 
     m_log.trace("%s: End of subthread", name());
   }
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/src/modules/bspwm.cpp
+++ b/src/modules/bspwm.cpp
@@ -35,7 +35,7 @@ namespace {
     }
     return (base & mask) == mask;
   }
-}
+}  // namespace
 
 namespace modules {
   template class module<bspwm_module>;
@@ -401,8 +401,8 @@ namespace modules {
       }
 
       for (auto&& ws : m_monitors[m_index]->workspaces) {
-        if (ws.second.get()) {
-          if(workspace_n != 0 && *m_labelseparator) {
+        if (ws.second) {
+          if (workspace_n != 0 && *m_labelseparator) {
             builder->node(m_labelseparator);
           }
 
@@ -506,6 +506,6 @@ namespace modules {
 
     return true;
   }
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/src/modules/counter.cpp
+++ b/src/modules/counter.cpp
@@ -25,6 +25,6 @@ namespace modules {
     }
     return false;
   }
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/src/modules/cpu.cpp
+++ b/src/modules/cpu.cpp
@@ -162,6 +162,6 @@ namespace modules {
 
     return math_util::cap<float>(percentage, 0, 100);
   }
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/src/modules/date.cpp
+++ b/src/modules/date.cpp
@@ -93,6 +93,6 @@ namespace modules {
     wakeup();
     return true;
   }
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/src/modules/fs.cpp
+++ b/src/modules/fs.cpp
@@ -102,8 +102,10 @@ namespace modules {
         mount->bytes_used = mount->bytes_total - mount->bytes_free;
         mount->bytes_avail = buffer.f_frsize * buffer.f_bavail;
 
-        mount->percentage_free = math_util::percentage<double>(mount->bytes_avail, mount->bytes_used + mount->bytes_avail);
-        mount->percentage_used = math_util::percentage<double>(mount->bytes_used, mount->bytes_used + mount->bytes_avail);
+        mount->percentage_free =
+            math_util::percentage<double>(mount->bytes_avail, mount->bytes_used + mount->bytes_avail);
+        mount->percentage_used =
+            math_util::percentage<double>(mount->bytes_used, mount->bytes_used + mount->bytes_avail);
       }
     }
 
@@ -180,6 +182,6 @@ namespace modules {
 
     return true;
   }
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/src/modules/github.cpp
+++ b/src/modules/github.cpp
@@ -90,12 +90,13 @@ namespace modules {
    * Build module content
    */
   bool github_module::build(builder* builder, const string& tag) const {
-    if (tag != TAG_LABEL)
+    if (tag != TAG_LABEL) {
       return false;
+    }
 
     builder->node(m_label);
     return true;
   }
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/src/modules/i3.cpp
+++ b/src/modules/i3.cpp
@@ -179,10 +179,9 @@ namespace modules {
          * The separator should only be inserted in between the workspaces, so
          * we insert it in front of all workspaces except the first one.
          */
-        if(first) {
+        if (first) {
           first = false;
-        }
-        else if (*m_labelseparator) {
+        } else if (*m_labelseparator) {
           builder->node(m_labelseparator);
         }
 
@@ -234,8 +233,7 @@ namespace modules {
       }
 
       auto workspaces = i3_util::workspaces(conn, m_bar.monitor->name);
-      auto current_ws = find_if(workspaces.begin(), workspaces.end(),
-                                [](auto ws) { return ws->visible; });
+      auto current_ws = find_if(workspaces.begin(), workspaces.end(), [](auto ws) { return ws->visible; });
 
       if (current_ws == workspaces.end()) {
         m_log.warn("%s: Current workspace not found", name());
@@ -264,6 +262,6 @@ namespace modules {
 
     return true;
   }
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/src/modules/ipc.cpp
+++ b/src/modules/ipc.cpp
@@ -123,6 +123,6 @@ namespace modules {
       broadcast();
     }
   }
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/src/modules/memory.cpp
+++ b/src/modules/memory.cpp
@@ -26,10 +26,10 @@ namespace modules {
     if (m_formatter->has(TAG_BAR_FREE)) {
       m_bar_memfree = load_progressbar(m_bar, m_conf, name(), TAG_BAR_FREE);
     }
-    if(m_formatter->has(TAG_RAMP_USED)) {
+    if (m_formatter->has(TAG_RAMP_USED)) {
       m_ramp_memused = load_ramp(m_conf, name(), TAG_RAMP_USED);
     }
-    if(m_formatter->has(TAG_RAMP_FREE)) {
+    if (m_formatter->has(TAG_RAMP_FREE)) {
       m_ramp_memfree = load_ramp(m_conf, name(), TAG_RAMP_FREE);
     }
     if (m_formatter->has(TAG_LABEL)) {
@@ -52,7 +52,9 @@ namespace modules {
         size_t sep_off = line.find(':');
         size_t value_off = line.find_first_of("123456789", sep_off);
 
-        if (sep_off == std::string::npos || value_off == std::string::npos) continue;
+        if (sep_off == std::string::npos || value_off == std::string::npos) {
+          continue;
+        }
 
         std::string id = line.substr(0, sep_off);
         unsigned long long int value = std::strtoull(&line[value_off], nullptr, 10);
@@ -64,7 +66,8 @@ namespace modules {
       kb_swap_free = parsed["SwapFree"];
 
       // newer kernels (3.4+) have an accurate available memory field,
-      // see https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=34e431b0ae398fc54ea69ff85ec700722c9da773
+      // see
+      // https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=34e431b0ae398fc54ea69ff85ec700722c9da773
       // for details
       if (parsed.count("MemAvailable")) {
         kb_avail = parsed["MemAvailable"];
@@ -121,6 +124,6 @@ namespace modules {
     }
     return true;
   }
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/src/modules/menu.cpp
+++ b/src/modules/menu.cpp
@@ -15,14 +15,13 @@ namespace modules {
     m_expand_right = m_conf.get(name(), "expand-right", m_expand_right);
 
     string default_format;
-    if(m_expand_right) {
+    if (m_expand_right) {
       default_format += TAG_LABEL_TOGGLE;
       default_format += TAG_MENU;
     } else {
       default_format += TAG_MENU;
       default_format += TAG_LABEL_TOGGLE;
     }
-
 
     m_formatter->add(DEFAULT_FORMAT, default_format, {TAG_LABEL_TOGGLE, TAG_MENU});
 
@@ -76,14 +75,14 @@ namespace modules {
       auto spacing = m_formatter->get(get_format())->spacing;
       for (auto&& item : m_levels[m_level]->items) {
         /*
-         * Depending on whether the menu items are to the left or right of the toggle label, the items need to be 
+         * Depending on whether the menu items are to the left or right of the toggle label, the items need to be
          * drawn before or after the spacings and the separator
          *
          * If the menu expands to the left, the separator should be drawn on the right side because otherwise the menu
          * would look like this:
          * | x | y <label-toggle>
          */
-        if(!m_expand_right) {
+        if (!m_expand_right) {
           builder->cmd(mousebtn::LEFT, item->exec);
           builder->node(item->label);
           builder->cmd_close();
@@ -102,7 +101,7 @@ namespace modules {
          * would look like this:
          * <label-toggle> x | y |
          */
-        if(m_expand_right) {
+        if (m_expand_right) {
           builder->cmd(mousebtn::LEFT, item->exec);
           builder->node(item->label);
           builder->cmd_close();
@@ -149,6 +148,6 @@ namespace modules {
     broadcast();
     return true;
   }
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/src/modules/meta/base.cpp
+++ b/src/modules/meta/base.cpp
@@ -80,8 +80,9 @@ namespace modules {
   // module_formatter {{{
 
   void module_formatter::add(string name, string fallback, vector<string>&& tags, vector<string>&& whitelist) {
-    const auto formatdef = [&](
-        const string& param, const auto& fallback) { return m_conf.get("settings", "format-" + param, fallback); };
+    const auto formatdef = [&](const string& param, const auto& fallback) {
+      return m_conf.get("settings", "format-" + param, fallback);
+    };
 
     auto format = make_unique<module_format>();
     format->value = m_conf.get(m_modname, name, move(fallback));
@@ -158,6 +159,6 @@ namespace modules {
   }
 
   // }}}
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/src/modules/mpd.cpp
+++ b/src/modules/mpd.cpp
@@ -37,7 +37,6 @@ namespace modules {
       mod_format->padding = m_conf.get(name(), FORMAT_ONLINE + "-padding"s, mod_format->padding);
       mod_format->margin = m_conf.get(name(), FORMAT_ONLINE + "-margin"s, mod_format->margin);
       mod_format->offset = m_conf.get(name(), FORMAT_ONLINE + "-offset"s, mod_format->offset);
-
     }
 
     m_formatter->add(FORMAT_OFFLINE, "", {TAG_LABEL_OFFLINE});
@@ -383,6 +382,6 @@ namespace modules {
 
     return true;
   }
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -180,6 +180,6 @@ namespace modules {
 
     m_log.trace("%s: Reached end of network subthread", name());
   }
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/src/modules/pulseaudio.cpp
+++ b/src/modules/pulseaudio.cpp
@@ -14,7 +14,8 @@ POLYBAR_NS
 namespace modules {
   template class module<pulseaudio_module>;
 
-  pulseaudio_module::pulseaudio_module(const bar_settings& bar, string name_) : event_module<pulseaudio_module>(bar, move(name_)) {
+  pulseaudio_module::pulseaudio_module(const bar_settings& bar, string name_)
+      : event_module<pulseaudio_module>(bar, move(name_)) {
     // Load configuration values
     auto sink_name = m_conf.get(name(), "sink", ""s);
     try {
@@ -149,6 +150,6 @@ namespace modules {
 
     return true;
   }
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/src/modules/script.cpp
+++ b/src/modules/script.cpp
@@ -175,7 +175,6 @@ namespace modules {
     string output{module::get_output()};
 
     for (auto btn : {mousebtn::LEFT, mousebtn::MIDDLE, mousebtn::RIGHT, mousebtn::SCROLL_UP, mousebtn::SCROLL_DOWN}) {
-
       auto action = m_actions[btn];
 
       if (!action.empty()) {
@@ -185,7 +184,7 @@ namespace modules {
          * The pid token is only for tailed commands.
          * If the command is not specified or running, replacement is unnecessary as well
          */
-        if(m_tail && m_command && m_command->is_running()) {
+        if (m_tail && m_command && m_command->is_running()) {
           m_builder->cmd(btn, string_util::replace_all(action, "%pid%", to_string(m_command->get_pid())));
         }
       }
@@ -208,6 +207,6 @@ namespace modules {
 
     return true;
   }
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/src/modules/systray.cpp
+++ b/src/modules/systray.cpp
@@ -65,7 +65,7 @@ namespace modules {
 
     return true;
   }
-}
+}  // namespace modules
 
 POLYBAR_NS_END
 #endif

--- a/src/modules/temperature.cpp
+++ b/src/modules/temperature.cpp
@@ -1,10 +1,10 @@
 #include "modules/temperature.hpp"
 
+#include <cmath>
 #include "drawtypes/label.hpp"
 #include "drawtypes/ramp.hpp"
 #include "utils/file.hpp"
 #include "utils/math.hpp"
-#include <cmath>
 
 #include "modules/meta/base.inl"
 
@@ -43,7 +43,7 @@ namespace modules {
     }
 
     // Deprecation warning for the %temperature% token
-    if((m_label[temp_state::NORMAL] && m_label[temp_state::NORMAL]->has_token("%temperature%")) ||
+    if ((m_label[temp_state::NORMAL] && m_label[temp_state::NORMAL]->has_token("%temperature%")) ||
         ((m_label[temp_state::WARN] && m_label[temp_state::WARN]->has_token("%temperature%")))) {
       m_log.warn("%s: The token `%%temperature%%` is deprecated, use `%%temperature-c%%` instead.", name());
     }
@@ -58,7 +58,7 @@ namespace modules {
     string temp_f_string = to_string(m_temp_f);
 
     // Add units if `units = true` in config
-    if(m_units) {
+    if (m_units) {
       temp_c_string += "°C";
       temp_f_string += "°F";
     }
@@ -102,6 +102,6 @@ namespace modules {
     }
     return true;
   }
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/src/modules/text.cpp
+++ b/src/modules/text.cpp
@@ -54,6 +54,6 @@ namespace modules {
 
     return m_builder->flush();
   }
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/src/modules/xbacklight.cpp
+++ b/src/modules/xbacklight.cpp
@@ -177,6 +177,6 @@ namespace modules {
 
     return true;
   }
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/src/modules/xkeyboard.cpp
+++ b/src/modules/xkeyboard.cpp
@@ -197,6 +197,6 @@ namespace modules {
       update();
     }
   }
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/src/modules/xwindow.cpp
+++ b/src/modules/xwindow.cpp
@@ -134,6 +134,6 @@ namespace modules {
     }
     return false;
   }
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/src/modules/xworkspaces.cpp
+++ b/src/modules/xworkspaces.cpp
@@ -17,7 +17,7 @@ namespace {
   inline bool operator==(const position& a, const position& b) {
     return a.x + a.y == b.x + b.y;
   }
-}
+}  // namespace
 
 namespace modules {
   template class module<xworkspaces_module>;
@@ -165,11 +165,11 @@ namespace modules {
 
     unsigned int step = m_desktop_names.size() / bounds.size();
     unsigned int offset = 0;
-    for (unsigned int i = 0; i < bounds.size(); i++) {
-      if (!m_pinworkspaces || m_bar.monitor->match(bounds[i])) {
+    for (auto bound : bounds) {
+      if (!m_pinworkspaces || m_bar.monitor->match(bound)) {
         auto viewport = make_unique<struct viewport>();
         viewport->state = viewport_state::UNFOCUSED;
-        viewport->pos = bounds[i];
+        viewport->pos = bound;
 
         for (auto&& m : m_monitors) {
           if (m->match(viewport->pos)) {
@@ -208,7 +208,7 @@ namespace modules {
           d->state = desktop_state::ACTIVE;
         } else {
           d->state = desktop_state::EMPTY;
-        } 
+        }
 
         d->label = m_labels.at(d->state)->clone();
         d->label->reset_tokens();
@@ -224,9 +224,10 @@ namespace modules {
    */
   void xworkspaces_module::set_desktop_urgent(xcb_window_t window) {
     auto desk = ewmh_util::get_desktop_from_window(window);
-    if(desk == m_current_desktop)
+    if (desk == m_current_desktop) {
       // ignore if current desktop is urgent
       return;
+    }
     for (auto&& v : m_viewports) {
       for (auto&& d : v->desktops) {
         if (d->index == desk && d->state != desktop_state::URGENT) {
@@ -241,7 +242,6 @@ namespace modules {
         }
       }
     }
-
   }
 
   /**
@@ -291,7 +291,7 @@ namespace modules {
     } else if (tag == TAG_LABEL_STATE) {
       unsigned int added_states = 0;
       for (auto&& desktop : m_viewports[m_index]->desktops) {
-        if (desktop->label.get()) {
+        if (desktop->label) {
           if (m_click && desktop->state != desktop_state::ACTIVE) {
             builder->cmd(mousebtn::LEFT, string{EVENT_PREFIX} + string{EVENT_CLICK} + to_string(desktop->index));
             builder->node(desktop->label);
@@ -349,6 +349,6 @@ namespace modules {
 
     return true;
   }
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/src/utils/bspwm.cpp
+++ b/src/utils/bspwm.cpp
@@ -146,6 +146,6 @@ namespace bspwm_util {
     }
     return conn;
   }
-}
+}  // namespace bspwm_util
 
 POLYBAR_NS_END

--- a/src/utils/concurrency.cpp
+++ b/src/utils/concurrency.cpp
@@ -26,6 +26,6 @@ namespace concurrency_util {
     }
     return ids[id];
   }
-}
+}  // namespace concurrency_util
 
 POLYBAR_NS_END

--- a/src/utils/env.cpp
+++ b/src/utils/env.cpp
@@ -17,6 +17,6 @@ namespace env_util {
     const char* value{std::getenv(var.c_str())};
     return value != nullptr ? value : move(fallback);
   }
-}
+}  // namespace env_util
 
 POLYBAR_NS_END

--- a/src/utils/file.cpp
+++ b/src/utils/file.cpp
@@ -240,7 +240,7 @@ namespace file_util {
     string ret;
     vector<string> p_exploded = string_util::split(path, '/');
     for (auto& section : p_exploded) {
-      switch(section[0]) {
+      switch (section[0]) {
         case '$':
           section = env_util::get(section.substr(1));
           break;
@@ -250,10 +250,11 @@ namespace file_util {
       }
     }
     ret = string_util::join(p_exploded, "/");
-    if (ret[0] != '/')
+    if (ret[0] != '/') {
       ret.insert(0, 1, '/');
+    }
     return ret;
   }
-}
+}  // namespace file_util
 
 POLYBAR_NS_END

--- a/src/utils/i3.cpp
+++ b/src/utils/i3.cpp
@@ -78,6 +78,6 @@ namespace i3_util {
     }
     return false;
   }
-}
+}  // namespace i3_util
 
 POLYBAR_NS_END

--- a/src/utils/io.cpp
+++ b/src/utils/io.cpp
@@ -91,6 +91,6 @@ namespace io_util {
       throw system_error("Failed to set O_NONBLOCK");
     }
   }
-}
+}  // namespace io_util
 
 POLYBAR_NS_END

--- a/src/utils/process.cpp
+++ b/src/utils/process.cpp
@@ -105,6 +105,6 @@ namespace process_util {
   bool notify_childprocess() {
     return wait_for_completion_nohang() > 0;
   }
-}
+}  // namespace process_util
 
 POLYBAR_NS_END

--- a/src/utils/socket.cpp
+++ b/src/utils/socket.cpp
@@ -115,6 +115,6 @@ namespace socket_util {
 
     return fds[0].revents & events;
   }
-}
+}  // namespace socket_util
 
 POLYBAR_NS_END

--- a/src/utils/string.cpp
+++ b/src/utils/string.cpp
@@ -178,8 +178,9 @@ namespace string_util {
     auto it = value.begin();
     auto end = value.end();
     for (size_t i = 0; i < len; ++i) {
-      if (it == end)
+      if (it == end) {
         break;
+      }
       ++it;
       it = std::find_if(it, end, [](char c) { return (c & 0xc0) != 0x80; });
     }
@@ -275,6 +276,6 @@ namespace string_util {
   hash_type hash(const string& src) {
     return std::hash<string>()(src);
   }
-}
+}  // namespace string_util
 
 POLYBAR_NS_END

--- a/src/utils/throttle.cpp
+++ b/src/utils/throttle.cpp
@@ -30,7 +30,7 @@ namespace throttle_util {
       }
       return true;
     }
-  }
-}
+  }  // namespace strategy
+}  // namespace throttle_util
 
 POLYBAR_NS_END

--- a/src/x11/cursor.cpp
+++ b/src/x11/cursor.cpp
@@ -3,27 +3,26 @@
 POLYBAR_NS
 
 namespace cursor_util {
-  bool valid(string name) {
-    if (cursors.find(name) != cursors.end())
-      return true;
-    return false;
+  bool valid(const string& name) {
+    return (cursors.find(name) != cursors.end());
   }
 
-  bool set_cursor(xcb_connection_t *c, xcb_screen_t *screen, xcb_window_t w, string name) {
+  bool set_cursor(xcb_connection_t* c, xcb_screen_t* screen, xcb_window_t w, const string& name) {
     xcb_cursor_t cursor = XCB_CURSOR_NONE;
-    xcb_cursor_context_t *ctx;
+    xcb_cursor_context_t* ctx;
 
     if (xcb_cursor_context_new(c, screen, &ctx) < 0) {
       return false;
     }
     for (auto&& cursor_name : cursors.at(name)) {
       cursor = xcb_cursor_load_cursor(ctx, cursor_name.c_str());
-      if (cursor != XCB_CURSOR_NONE)
+      if (cursor != XCB_CURSOR_NONE) {
         break;
+      }
     }
     xcb_change_window_attributes(c, w, XCB_CW_CURSOR, &cursor);
     xcb_cursor_context_free(ctx);
     return true;
   }
-}
+}  // namespace cursor_util
 POLYBAR_NS_END

--- a/src/x11/ewmh.cpp
+++ b/src/x11/ewmh.cpp
@@ -133,7 +133,7 @@ namespace ewmh_util {
 
   vector<xcb_atom_t> get_wm_state(xcb_window_t win) {
     auto conn = initialize().get();
-    xcb_ewmh_get_atoms_reply_t reply;
+    xcb_ewmh_get_atoms_reply_t reply{};
     if (xcb_ewmh_get_wm_state_reply(conn, xcb_ewmh_get_wm_state(conn, win), &reply, nullptr)) {
       return {reply.atoms, reply.atoms + reply.atoms_len};
     }
@@ -167,12 +167,12 @@ namespace ewmh_util {
 
   vector<xcb_window_t> get_client_list(int screen) {
     auto conn = initialize().get();
-    xcb_ewmh_get_windows_reply_t reply;
+    xcb_ewmh_get_windows_reply_t reply{};
     if (xcb_ewmh_get_client_list_reply(conn, xcb_ewmh_get_client_list(conn, screen), &reply, nullptr)) {
       return {reply.windows, reply.windows + reply.windows_len};
     }
     return {};
   }
-}
+}  // namespace ewmh_util
 
 POLYBAR_NS_END

--- a/src/x11/extensions/composite.cpp
+++ b/src/x11/extensions/composite.cpp
@@ -17,6 +17,6 @@ namespace composite_util {
     }
 #endif
   }
-}
+}  // namespace composite_util
 
 POLYBAR_NS_END

--- a/src/x11/extensions/damage.cpp
+++ b/src/x11/extensions/damage.cpp
@@ -15,6 +15,6 @@ namespace damage_util {
       throw application_error("Missing X extension: Damage");
     }
   }
-}
+}  // namespace damage_util
 
 POLYBAR_NS_END

--- a/src/x11/extensions/randr.cpp
+++ b/src/x11/extensions/randr.cpp
@@ -213,6 +213,6 @@ namespace randr_util {
       dst.val = static_cast<double>(value);
     }
   }
-}
+}  // namespace randr_util
 
 POLYBAR_NS_END

--- a/src/x11/extensions/render.cpp
+++ b/src/x11/extensions/render.cpp
@@ -15,6 +15,6 @@ namespace render_util {
       throw application_error("Missing X extension: Render");
     }
   }
-}
+}  // namespace render_util
 
 POLYBAR_NS_END

--- a/src/x11/extensions/sync.cpp
+++ b/src/x11/extensions/sync.cpp
@@ -17,6 +17,6 @@ namespace sync_util {
       throw application_error("Missing X extension: Sync");
     }
   }
-}
+}  // namespace sync_util
 
 POLYBAR_NS_END

--- a/src/x11/extensions/xkb.cpp
+++ b/src/x11/extensions/xkb.cpp
@@ -210,6 +210,6 @@ namespace xkb_util {
     }
     return name;
   }
-}
+}  // namespace xkb_util
 
 POLYBAR_NS_END

--- a/src/x11/icccm.cpp
+++ b/src/x11/icccm.cpp
@@ -31,13 +31,14 @@ namespace icccm_util {
   }
 
   bool get_wm_urgency(xcb_connection_t* c, xcb_window_t w) {
-    xcb_icccm_wm_hints_t hints;
-    if (xcb_icccm_get_wm_hints_reply(c, xcb_icccm_get_wm_hints(c, w), &hints, NULL)) {
-      if(xcb_icccm_wm_hints_get_urgency(&hints) == XCB_ICCCM_WM_HINT_X_URGENCY)
+    xcb_icccm_wm_hints_t hints{};
+    if (xcb_icccm_get_wm_hints_reply(c, xcb_icccm_get_wm_hints(c, w), &hints, nullptr)) {
+      if (xcb_icccm_wm_hints_get_urgency(&hints) == XCB_ICCCM_WM_HINT_X_URGENCY) {
         return true;
+      }
     }
     return false;
   }
-}
+}  // namespace icccm_util
 
 POLYBAR_NS_END

--- a/src/x11/window.cpp
+++ b/src/x11/window.cpp
@@ -1,9 +1,9 @@
+#include "x11/window.hpp"
 #include "components/types.hpp"
 #include "utils/memory.hpp"
 #include "x11/atoms.hpp"
 #include "x11/connection.hpp"
 #include "x11/extensions/randr.hpp"
-#include "x11/window.hpp"
 
 POLYBAR_NS
 

--- a/src/x11/winspec.cpp
+++ b/src/x11/winspec.cpp
@@ -1,4 +1,5 @@
 #include "x11/connection.hpp"
+
 #include "x11/winspec.hpp"
 
 POLYBAR_NS

--- a/src/x11/xembed.cpp
+++ b/src/x11/xembed.cpp
@@ -96,6 +96,6 @@ namespace xembed {
       // invalid window
     }
   }
-}
+}  // namespace xembed
 
 POLYBAR_NS_END


### PR DESCRIPTION
The code hasn't been cleaned for a while so I ran clang-tidy and clang-format. Most of it is just reordering of includes, commenting namespaces, and various other formatting stuff. There were a few parts where I refactored the code a little as suggested by clang-tidy.

For future reference, these can be run with `cmake --build build/ --target {codeformat,codecheck,codecheck-fix}` (format, tidy, format + tidy).