### PR TITLE
aur: Add i3-wm dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ A compiler with C++14 support ([clang-3.4+](http://llvm.org/releases/download.ht
 **Optional dependencies for extended module support:**
 - alsa-lib *required by `internal/alsa`*
 - libpulse *required by `internal/pulseaudio`*
+- i3-wm *required by `internal/i3`*
 - jsoncpp *required by `internal/i3`*
 - libmpdclient *required by `internal/mpd`*
 - libcurl *required by `internal/github`*

--- a/contrib/polybar-git.aur/PKGBUILD
+++ b/contrib/polybar-git.aur/PKGBUILD
@@ -3,7 +3,7 @@
 _pkgname=polybar
 pkgname="${_pkgname}-git"
 pkgver=3.1.0
-pkgrel=2
+pkgrel=3
 pkgdesc="A fast and easy-to-use status bar"
 arch=("i686" "x86_64")
 url="https://github.com/jaagr/polybar"
@@ -14,6 +14,7 @@ optdepends=("alsa-lib: alsa module support"
             "libmpdclient: mpd module support"
             "wireless_tools: network module support"
             "jsoncpp: i3 module support"
+            "i3-wm: i3 module support"
             "ttf-unifont: Font used in example config"
             "siji-git: Font used in example config"
             "curl: github module support")

--- a/contrib/polybar.aur/PKGBUILD
+++ b/contrib/polybar.aur/PKGBUILD
@@ -2,7 +2,7 @@
 # Contributor: Michael Carlberg <c@rlberg.se>
 pkgname=polybar
 pkgver=3.1.0
-pkgrel=3
+pkgrel=4
 pkgdesc="A fast and easy-to-use status bar"
 arch=("i686" "x86_64")
 url="https://github.com/jaagr/polybar"
@@ -12,6 +12,7 @@ optdepends=("alsa-lib: alsa module support"
             "libmpdclient: mpd module support"
             "wireless_tools: network module support"
             "jsoncpp: i3 module support"
+            "i3-wm: i3 module support"
             "ttf-unifont: Font used in example config"
             "siji-git: Font used in example config"
             "curl: github module support")


### PR DESCRIPTION
The actual i3 package is also needed to build polybar with i3 support.
It is also listed as a makedepends, like that polybar will always work
with i3, even if the user only decides to install i3 later on.