### PR TITLE
fix(pulseaudio): get default sink on new events when using default, add mutex

### DIFF
--- a/include/adapters/pulseaudio.hpp
+++ b/include/adapters/pulseaudio.hpp
@@ -2,6 +2,7 @@
 
 #include <pulse/pulseaudio.h>
 #include <queue>
+#include <mutex>
 
 #include "common.hpp"
 #include "settings.hpp"
@@ -17,6 +18,8 @@ typedef struct pa_threaded_mainloop pa_threaded_mainloop;
 
 POLYBAR_NS
 class logger;
+
+using mutex = std::mutex;
 
 DEFINE_ERROR(pulseaudio_error);
 
@@ -69,6 +72,8 @@ class pulseaudio {
     pa_threaded_mainloop* m_mainloop{nullptr};
 
     queue m_events;
+    mutable mutex m_mutex;
+
 
     // specified sink name
     string spec_s_name;

--- a/src/adapters/pulseaudio.cpp
+++ b/src/adapters/pulseaudio.cpp
@@ -124,8 +124,8 @@ int pulseaudio::process_events() {
         if (!spec_s_name.empty()) {
           o = pa_context_get_sink_info_by_name(m_context, spec_s_name.c_str(), sink_info_callback, this);
           wait_loop(o, m_mainloop);
+          break;
         }
-        break;
       // get default sink
       case evtype::REMOVE:
         o = pa_context_get_server_info(m_context, get_default_sink_callback, this);
@@ -138,7 +138,7 @@ int pulseaudio::process_events() {
           m_log.warn("pulseaudio: using default sink %s", s_name);
         break;
       default:
-	break;
+        break;
     }
     update_volume(o);
     m_events.pop();

--- a/src/adapters/pulseaudio.cpp
+++ b/src/adapters/pulseaudio.cpp
@@ -112,6 +112,8 @@ bool pulseaudio::wait() {
  * Process queued pulseaudio events
  */
 int pulseaudio::process_events() {
+  std::lock_guard<mutex> lock(m_mutex);
+
   int ret = m_events.size();
   pa_threaded_mainloop_lock(m_mainloop);
   pa_operation *o{nullptr};
@@ -245,6 +247,7 @@ void pulseaudio::subscribe_callback(pa_context *, pa_subscription_event_type_t t
     return;
   switch(t & PA_SUBSCRIPTION_EVENT_FACILITY_MASK) {
     case PA_SUBSCRIPTION_EVENT_SINK:
+      std::lock_guard<mutex> lock(This->m_mutex);
       switch(t & PA_SUBSCRIPTION_EVENT_TYPE_MASK) {
         case PA_SUBSCRIPTION_EVENT_NEW:
             This->m_events.emplace(evtype::NEW);

--- a/src/adapters/pulseaudio.cpp
+++ b/src/adapters/pulseaudio.cpp
@@ -128,6 +128,7 @@ int pulseaudio::process_events() {
           wait_loop(o, m_mainloop);
           break;
         }
+        // FALLTHRU
       // get default sink
       case evtype::REMOVE:
         o = pa_context_get_server_info(m_context, get_default_sink_callback, this);


### PR DESCRIPTION
The new event case should now fall through if there was no sink specified in the config, so it gets the current default sink.

I also added a mutex for the queue because the callback is on a separate thread compared to the module which calls `process_events()`.

Fixes #1086.