### PR TITLE
fix: remove .exrc

### DIFF
--- a/.exrc
+++ b/.exrc
@@ -1,3 +1,0 @@
-let &path.='include,src,'
-let tag_path='/home/jaagr/.local/src/c++/polybar/.tags'
-set tags+=/home/jaagr/.local/src/c++/polybar/.tags


### PR DESCRIPTION
This is oddly specific to jaagr's setup, and absolutely useless for everyone else.