### PR TITLE
fix(pulse): Use distinct event names

### DIFF
--- a/include/modules/pulseaudio.hpp
+++ b/include/modules/pulseaudio.hpp
@@ -35,10 +35,10 @@ namespace modules {
     static constexpr auto TAG_LABEL_VOLUME = "<label-volume>";
     static constexpr auto TAG_LABEL_MUTED = "<label-muted>";
 
-    static constexpr auto EVENT_PREFIX = "vol";
-    static constexpr auto EVENT_VOLUME_UP = "volup";
-    static constexpr auto EVENT_VOLUME_DOWN = "voldown";
-    static constexpr auto EVENT_TOGGLE_MUTE = "volmute";
+    static constexpr auto EVENT_PREFIX = "pa_vol";
+    static constexpr auto EVENT_VOLUME_UP = "pa_volup";
+    static constexpr auto EVENT_VOLUME_DOWN = "pa_voldown";
+    static constexpr auto EVENT_TOGGLE_MUTE = "pa_volmute";
 
     progressbar_t m_bar_volume;
     ramp_t m_ramp_volume;

--- a/src/modules/pulseaudio.cpp
+++ b/src/modules/pulseaudio.cpp
@@ -126,7 +126,7 @@ namespace modules {
   bool pulseaudio_module::input(string&& cmd) {
     if (!m_handle_events) {
       return false;
-    } else if (cmd.compare(0, 3, EVENT_PREFIX) != 0) {
+    } else if (cmd.compare(0, strlen(EVENT_PREFIX), EVENT_PREFIX) != 0) {
       return false;
     }
 


### PR DESCRIPTION
volup, voldow, volmute, are caught by the alsa module, if there is an
alsa module on the bar.