### PR TITLE
fix(log): Actually enable trace logging by default

### DIFF
--- a/include/settings.hpp.cmake
+++ b/include/settings.hpp.cmake
@@ -47,8 +47,9 @@
 
 #cmakedefine XPP_EXTENSION_LIST @XPP_EXTENSION_LIST@
 
-#if DEBUG
 #cmakedefine DEBUG_LOGGER
+
+#if DEBUG
 #cmakedefine DEBUG_LOGGER_VERBOSE
 #cmakedefine DEBUG_HINTS
 #cmakedefine DEBUG_WHITESPACE


### PR DESCRIPTION
I didn't notice the guard withing setting.hpp.cmake when I submitted #1057