### PR TITLE
Clear entire xwindow label if no window is open

### DIFF
--- a/include/modules/xwindow.hpp
+++ b/include/modules/xwindow.hpp
@@ -30,6 +30,11 @@ namespace modules {
    */
   class xwindow_module : public static_module<xwindow_module>, public event_handler<evt::property_notify> {
    public:
+    enum class state {
+      NONE,
+      ACTIVE,
+      EMPTY
+    };
     explicit xwindow_module(const bar_settings&, string);
 
     void update(bool force = false);
@@ -43,6 +48,7 @@ namespace modules {
 
     connection& m_connection;
     unique_ptr<active_window> m_active;
+    map<state, label_t> m_statelabels;
     label_t m_label;
   };
 }

--- a/src/modules/xwindow.cpp
+++ b/src/modules/xwindow.cpp
@@ -77,7 +77,10 @@ namespace modules {
     m_formatter->add(DEFAULT_FORMAT, TAG_LABEL, {TAG_LABEL});
 
     if (m_formatter->has(TAG_LABEL)) {
-      m_label = load_optional_label(m_conf, name(), TAG_LABEL, "%title%");
+      m_statelabels.insert(
+          make_pair(state::ACTIVE, load_optional_label(m_conf, name(), "label", "%title%")));
+      m_statelabels.insert(
+          make_pair(state::EMPTY, load_optional_label(m_conf, name(), "label-empty", "")));
     }
   }
 
@@ -118,9 +121,12 @@ namespace modules {
       m_active = make_unique<active_window>(m_connection, win);
     }
 
-    if (m_label) {
+    if (m_active) {
+      m_label = m_statelabels.find(state::ACTIVE)->second->clone();
       m_label->reset_tokens();
-      m_label->replace_token("%title%", m_active ? m_active->title() : "");
+      m_label->replace_token("%title%", m_active->title());
+    } else {
+      m_label = m_statelabels.find(state::EMPTY)->second->clone();
     }
   }
 

--- a/src/modules/xwindow.cpp
+++ b/src/modules/xwindow.cpp
@@ -77,10 +77,8 @@ namespace modules {
     m_formatter->add(DEFAULT_FORMAT, TAG_LABEL, {TAG_LABEL});
 
     if (m_formatter->has(TAG_LABEL)) {
-      m_statelabels.insert(
-          make_pair(state::ACTIVE, load_optional_label(m_conf, name(), "label", "%title%")));
-      m_statelabels.insert(
-          make_pair(state::EMPTY, load_optional_label(m_conf, name(), "label-empty", "")));
+      m_statelabels.emplace(state::ACTIVE, load_optional_label(m_conf, name(), "label", "%title%"));
+      m_statelabels.emplace(state::EMPTY, load_optional_label(m_conf, name(), "label-empty", ""));
     }
   }
 
@@ -122,11 +120,11 @@ namespace modules {
     }
 
     if (m_active) {
-      m_label = m_statelabels.find(state::ACTIVE)->second->clone();
+      m_label = m_statelabels.at(state::ACTIVE)->clone();
       m_label->reset_tokens();
       m_label->replace_token("%title%", m_active->title());
     } else {
-      m_label = m_statelabels.find(state::EMPTY)->second->clone();
+      m_label = m_statelabels.at(state::EMPTY)->clone();
     }
   }
 


### PR DESCRIPTION
If you use the current [config file](https://github.com/jaagr/polybar/wiki/Module:-xwindow) in the wiki entry for the xwindow module, not having an active window will still result in "Window: " being displayed in the bar. This doesn't really make sense IMO, so I added an if statement to clear the entire label (including the "Window: ") if there is no active window.

I could also add an option to make this configurable, but I don't really see why anyone would want the "Window: " to be displayed.