### PR TITLE
Revert "fix(pulseaudio): add mutex for queue"

### DIFF
--- a/include/adapters/pulseaudio.hpp
+++ b/include/adapters/pulseaudio.hpp
@@ -2,7 +2,6 @@
 
 #include <pulse/pulseaudio.h>
 #include <queue>
-#include <mutex>
 
 #include "common.hpp"
 #include "settings.hpp"
@@ -18,8 +17,6 @@ typedef struct pa_threaded_mainloop pa_threaded_mainloop;
 
 POLYBAR_NS
 class logger;
-
-using mutex = std::mutex;
 
 DEFINE_ERROR(pulseaudio_error);
 
@@ -72,8 +69,6 @@ class pulseaudio {
     pa_threaded_mainloop* m_mainloop{nullptr};
 
     queue m_events;
-    mutable mutex m_mutex;
-
 
     // specified sink name
     string spec_s_name;

--- a/src/adapters/pulseaudio.cpp
+++ b/src/adapters/pulseaudio.cpp
@@ -112,8 +112,6 @@ bool pulseaudio::wait() {
  * Process queued pulseaudio events
  */
 int pulseaudio::process_events() {
-  std::lock_guard<mutex> lock(m_mutex);
-
   int ret = m_events.size();
   pa_threaded_mainloop_lock(m_mainloop);
   pa_operation *o{nullptr};
@@ -248,7 +246,6 @@ void pulseaudio::subscribe_callback(pa_context *, pa_subscription_event_type_t t
     return;
   switch(t & PA_SUBSCRIPTION_EVENT_FACILITY_MASK) {
     case PA_SUBSCRIPTION_EVENT_SINK:
-      std::lock_guard<mutex> lock(This->m_mutex);
       switch(t & PA_SUBSCRIPTION_EVENT_TYPE_MASK) {
         case PA_SUBSCRIPTION_EVENT_NEW:
             This->m_events.emplace(evtype::NEW);


### PR DESCRIPTION
This reverts commit d430174f0b4c02d5dfc2eb818ed79410a2e19b4b.
Mutual exclusion is already guaranteed by the lock on
pa_threaded_mainloop

Fixes #1139