### PR TITLE
(pulseaudio) Add max volume configuration

### DIFF
--- a/include/adapters/pulseaudio.hpp
+++ b/include/adapters/pulseaudio.hpp
@@ -26,7 +26,7 @@ class pulseaudio {
   using queue = std::queue<evtype>;
 
   public:
-    explicit pulseaudio(const logger& logger, string&& sink_name);
+    explicit pulseaudio(const logger& logger, string&& sink_name, bool m_max_volume);
     ~pulseaudio();
 
     pulseaudio(const pulseaudio& o) = delete;
@@ -74,6 +74,8 @@ class pulseaudio {
     string spec_s_name;
     string s_name;
     uint32_t m_index{0};
+
+    pa_volume_t max_volume{PA_VOLUME_UI_MAX};
 };
 
 POLYBAR_NS_END

--- a/src/adapters/pulseaudio.cpp
+++ b/src/adapters/pulseaudio.cpp
@@ -6,7 +6,7 @@ POLYBAR_NS
 /**
  * Construct pulseaudio object
  */
-pulseaudio::pulseaudio(const logger& logger, string&& sink_name) : m_log(logger), spec_s_name(sink_name) {
+pulseaudio::pulseaudio(const logger& logger, string&& sink_name, bool m_max_volume) : m_log(logger), spec_s_name(sink_name) {
   m_mainloop = pa_threaded_mainloop_new();
   if (!m_mainloop) {
     throw pulseaudio_error("Could not create pulseaudio threaded mainloop.");
@@ -70,6 +70,8 @@ pulseaudio::pulseaudio(const logger& logger, string&& sink_name) : m_log(logger)
   } else {
     m_log.trace("pulseaudio: using sink %s", s_name);
   }
+
+  max_volume = m_max_volume ? PA_VOLUME_UI_MAX : PA_VOLUME_NORM;
 
   op = pa_context_subscribe(m_context, PA_SUBSCRIPTION_MASK_SINK, simple_callback, this);
   wait_loop(op, m_mainloop);
@@ -177,7 +179,7 @@ void pulseaudio::inc_volume(int delta_perc) {
   pa_threaded_mainloop_lock(m_mainloop);
   pa_volume_t vol = math_util::percentage_to_value<pa_volume_t>(abs(delta_perc), PA_VOLUME_NORM);
   if (delta_perc > 0) {
-    if (pa_cvolume_max(&cv) + vol <= PA_VOLUME_UI_MAX) {
+    if (pa_cvolume_max(&cv) + vol <= max_volume) {
       pa_cvolume_inc(&cv, vol);
     } else {
       m_log.warn("pulseaudio: maximum volume reached");

--- a/src/modules/pulseaudio.cpp
+++ b/src/modules/pulseaudio.cpp
@@ -17,8 +17,10 @@ namespace modules {
   pulseaudio_module::pulseaudio_module(const bar_settings& bar, string name_) : event_module<pulseaudio_module>(bar, move(name_)) {
     // Load configuration values
     auto sink_name = m_conf.get(name(), "sink", ""s);
+    bool m_max_volume = m_conf.get(name(), "use-ui-max", true);
+
     try {
-      m_pulseaudio = factory_util::unique<pulseaudio>(m_log, move(sink_name));
+      m_pulseaudio = factory_util::unique<pulseaudio>(m_log, move(sink_name), m_max_volume);
     } catch (const pulseaudio_error& err) {
       throw module_error(err.what());
     }


### PR DESCRIPTION
Adds `max-volume` configuration.
If set to `true`  volume is capped at 150%, 
if `false`it's capped at 100%, 
unset = `true`

Fixes #1125 