### PR TITLE
xworkspaces: Deprecate pin-workspaces

### DIFF
--- a/src/modules/xworkspaces.cpp
+++ b/src/modules/xworkspaces.cpp
@@ -32,6 +32,12 @@ namespace modules {
     m_click = m_conf.get(name(), "enable-click", m_click);
     m_scroll = m_conf.get(name(), "enable-scroll", m_scroll);
 
+    if(m_pinworkspaces) {
+      m_log.warn("%s: The config parameter `pin-workspaces = true` is deprecated, "
+          "as defining a workspace on an output only is not a general WM concept. "
+          "Please stop using `pin-workspaces`, you may experience weird behaviour", name());
+    }
+
     // Initialize ewmh atoms
     if ((m_ewmh = ewmh_util::initialize()) == nullptr) {
       throw module_error("Failed to initialize ewmh atoms");


### PR DESCRIPTION
The ewmh spec ([1]) doesn't have a notion of mapping a workspace to a
monitor. Whatever polybar does when pin-workspaces is true, may be
totally different than what the WM does, because it can't tell us how
the workspaces are mapped with ewmh atoms.

[1]: https://specifications.freedesktop.org/wm-spec/wm-spec-latest.html