### PR TITLE
fix(net): Mark not connected on querying failure

### DIFF
--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -86,6 +86,7 @@ namespace modules {
 
     if (!network->query(m_accumulate)) {
       m_log.warn("%s: Failed to query interface '%s'", name(), m_interface);
+      m_connected = false;
       return false;
     }
 


### PR DESCRIPTION
I don't see a reason why not to treat a negative result from `network::query` as a reason why the interface is down.
Is there something I'm missing here @NBonaparte?

Fixes #1163