### PR TITLE
fix(builder): Respect label-ellipsis option

### DIFF
--- a/common/travis/tests.sh
+++ b/common/travis/tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 r=0
 
-make all_unit_tests
+make all_unit_tests || exit $?
 
 for test in tests/unit_test.*; do
   [ -x "$test" ] || continue

--- a/include/components/builder.hpp
+++ b/include/components/builder.hpp
@@ -59,6 +59,8 @@ class builder {
   string background_hex();
   string foreground_hex();
 
+  string get_label_text(const label_t& label);
+
   void tag_open(syntaxtag tag, const string& value);
   void tag_open(attribute attr);
   void tag_close(syntaxtag tag);

--- a/include/drawtypes/label.hpp
+++ b/include/drawtypes/label.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cassert>
+
 #include "common.hpp"
 #include "components/config.hpp"
 #include "components/types.hpp"
@@ -37,6 +39,14 @@ namespace drawtypes {
     int m_font{0};
     side_values m_padding{0U,0U};
     side_values m_margin{0U,0U};
+
+    /*
+     * If m_ellipsis is true, m_maxlen MUST be larger or equal to the length of
+     * the ellipsis (3), everything else is a programming error
+     *
+     * load_label should take care of this, but be aware, if you are creating
+     * labels in a different way.
+     */
     size_t m_maxlen{0_z};
     bool m_ellipsis{true};
 
@@ -55,7 +65,9 @@ namespace drawtypes {
         , m_ellipsis(ellipsis)
         , m_text(text)
         , m_tokenized(m_text)
-        , m_tokens(forward<vector<token>>(tokens)) {}
+        , m_tokens(forward<vector<token>>(tokens)) {
+          assert(!m_ellipsis || (m_maxlen == 0 || m_maxlen >= 3));
+        }
 
     string get() const;
     operator bool();

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -87,5 +87,7 @@ endif()
 
 # }}}
 
+# Export source file list so that it can be used for test compilation
+set(files ${files} PARENT_SCOPE)
 set(libs ${libs} PARENT_SCOPE)
 set(dirs ${dirs} PARENT_SCOPE)

--- a/src/components/builder.cpp
+++ b/src/components/builder.cpp
@@ -559,8 +559,21 @@ string builder::foreground_hex() {
 string builder::get_label_text(const label_t& label) {
   string text{label->get()};
 
-  if (label->m_maxlen > 0 && string_util::char_len(text) > label->m_maxlen) {
-    text = string_util::utf8_truncate(std::move(text), label->m_maxlen) + "...";
+  size_t maxlen = label->m_maxlen;
+
+  if (maxlen > 0 && string_util::char_len(text) > maxlen ) {
+    if(label->m_ellipsis) {
+      if(maxlen < 3) {
+        throw application_error(sstream()
+            << "Label has maxlen (" << maxlen
+            << ") that is smaller than size of ellipsis(3)");
+      }
+
+      text = string_util::utf8_truncate(std::move(text), maxlen - 3) + "...";
+    }
+    else {
+      text = string_util::utf8_truncate(std::move(text), maxlen);
+    }
   }
 
   return text;

--- a/src/components/builder.cpp
+++ b/src/components/builder.cpp
@@ -561,14 +561,8 @@ string builder::get_label_text(const label_t& label) {
 
   size_t maxlen = label->m_maxlen;
 
-  if (maxlen > 0 && string_util::char_len(text) > maxlen ) {
-    if(label->m_ellipsis) {
-      if(maxlen < 3) {
-        throw application_error(sstream()
-            << "Label has maxlen (" << maxlen
-            << ") that is smaller than size of ellipsis(3)");
-      }
-
+  if (maxlen > 0 && string_util::char_len(text) > maxlen) {
+    if (label->m_ellipsis) {
       text = string_util::utf8_truncate(std::move(text), maxlen - 3) + "...";
     }
     else {

--- a/src/components/builder.cpp
+++ b/src/components/builder.cpp
@@ -206,11 +206,7 @@ void builder::node(const label_t& label, bool add_space) {
     return;
   }
 
-  string text{label->get()};
-
-  if (label->m_maxlen > 0 && string_util::char_len(text) > label->m_maxlen) {
-    text = string_util::utf8_truncate(std::move(text), label->m_maxlen) + "...";
-  }
+  auto text = get_label_text(label);
 
   // if ((label->m_overline.empty() && m_tags[syntaxtag::o] > 0) || (m_tags[syntaxtag::o] > 0 && label->m_margin > 0))
   //   overline_close();
@@ -558,6 +554,16 @@ string builder::foreground_hex() {
     m_foreground = color_util::hex<unsigned short int>(m_bar.foreground);
   }
   return m_foreground;
+}
+
+string builder::get_label_text(const label_t& label) {
+  string text{label->get()};
+
+  if (label->m_maxlen > 0 && string_util::char_len(text) > label->m_maxlen) {
+    text = string_util::utf8_truncate(std::move(text), label->m_maxlen) + "...";
+  }
+
+  return text;
 }
 
 /**

--- a/src/drawtypes/label.cpp
+++ b/src/drawtypes/label.cpp
@@ -221,6 +221,17 @@ namespace drawtypes {
       }
     }
 
+    size_t maxlen = conf.get(section, name + "-maxlen", 0_z);
+    bool ellipsis = conf.get(section, name + "-ellipsis", true);
+
+    if(ellipsis && maxlen > 0 && maxlen < 3) {
+      logger::make().err(sstream() << "Label " << section << "." << name
+          << " has maxlen " << maxlen
+          << ", which is smaller than length of ellipsis (3), disabling ellipsis...");
+
+      ellipsis = false;
+    }
+
     // clang-format off
     return factory_util::shared<label>(text,
         conf.get(section, name + "-foreground", ""s),
@@ -230,8 +241,8 @@ namespace drawtypes {
         conf.get(section, name + "-font", 0),
         padding,
         margin,
-        conf.get(section, name + "-maxlen", 0_z),
-        conf.get(section, name + "-ellipsis", true),
+        maxlen,
+        ellipsis,
         move(tokens));
     // clang-format on
   }

--- a/src/drawtypes/label.cpp
+++ b/src/drawtypes/label.cpp
@@ -225,11 +225,10 @@ namespace drawtypes {
     bool ellipsis = conf.get(section, name + "-ellipsis", true);
 
     if(ellipsis && maxlen > 0 && maxlen < 3) {
-      logger::make().err(sstream() << "Label " << section << "." << name
+      throw application_error(sstream()
+          << "Label " << section << "." << name
           << " has maxlen " << maxlen
-          << ", which is smaller than length of ellipsis (3), disabling ellipsis...");
-
-      ellipsis = false;
+          << ", which is smaller than length of ellipsis (3)");
     }
 
     // clang-format off

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -44,7 +44,10 @@ function(unit_test file tests)
   # unit_test function become cleaner
   SET(sources "")
   FOREACH(f ${BIN_SOURCES})
-    LIST(APPEND sources "../src/${f}")
+    # Do not add main.cpp, because it will override the main function
+    if(NOT "${f}" STREQUAL "main.cpp")
+      LIST(APPEND sources "../src/${f}")
+    endif()
   ENDFOREACH(f)
 
   string(REPLACE "/" "_" testname ${file})
@@ -81,6 +84,10 @@ unit_test(components/command_line unit_tests
   SOURCES
   components/command_line.cpp
   utils/string.cpp)
+
+unit_test(components/builder unit_tests
+  SOURCES
+  ${files})
 
 # Compile all unit tests with 'make all_unit_tests'
 add_custom_target("all_unit_tests" DEPENDS ${unit_tests})

--- a/tests/unit_tests/components/builder.cpp
+++ b/tests/unit_tests/components/builder.cpp
@@ -1,0 +1,79 @@
+#include <tuple>
+
+#include "common/test.hpp"
+#include "components/builder.hpp"
+#include "components/types.hpp"
+#include "utils/factory.hpp"
+#include "drawtypes/label.hpp"
+
+using namespace polybar;
+using namespace std;
+
+/**
+ * \brief Testing-only subclass of builder to change access level
+ */
+class TestableBuilder : public builder {
+  using builder::builder;
+  public: using builder::get_label_text;
+};
+
+class Builder : public ::testing::Test {
+  protected:
+
+    /**
+     * Generic bar settings
+     *
+     * Builder only needs spacing and background
+     */
+    bar_settings m_bar{};
+    TestableBuilder m_builder{m_bar};
+};
+
+// GetLabelTextTest {{{
+
+/**
+ * \brief Class for parameterized tests on get_label_text
+ *
+ * The first element of the pair is the expected returned text, the second
+ * element is a triple containing the original label text, m_ellipsis and
+ * m_maxlen, in that order
+ */
+class GetLabelTextTest :
+  public Builder,
+  public ::testing::WithParamInterface<pair<string, tuple<string, bool, int>>> {};
+
+vector<pair<string, tuple<string, bool, int>>> get_label_text_list = {
+  {"...", make_tuple("abcd", true, 3)},
+  {"abc", make_tuple("abcdefgh", false, 3)},
+  {"a...", make_tuple("abcdefgh", true, 4)},
+  {"abcd...", make_tuple("abcdefgh", true, 7)},
+  {"abcdefgh", make_tuple("abcdefgh", true, 8)},
+};
+
+INSTANTIATE_TEST_CASE_P(Inst, GetLabelTextTest,
+    ::testing::ValuesIn(get_label_text_list),);
+
+TEST_P(GetLabelTextTest, correctness) {
+  label_t m_label = factory_util::shared<label>(get<0>(GetParam().second));
+  m_label->m_ellipsis = get<1>(GetParam().second);
+  m_label->m_maxlen = get<2>(GetParam().second);
+
+  auto text = m_builder.get_label_text(m_label);
+  EXPECT_EQ(GetParam().first, text);
+
+  EXPECT_LE(text.length(), m_label->m_maxlen) << "Returned text is longer than maxlen";
+}
+
+/**
+ * \brief Tests, if get_label_text throws an exception, when ellipsis is
+ *        turned on and m_maxlen is lower than 3 (length of the ellipsis)
+ */
+TEST_F(GetLabelTextTest, throwsException) {
+  label_t m_label = factory_util::shared<label>("abcdef");
+  m_label->m_ellipsis = true;
+  m_label->m_maxlen = 2;
+
+  EXPECT_ANY_THROW(m_builder.get_label_text(m_label));
+}
+
+// }}}

--- a/tests/unit_tests/components/builder.cpp
+++ b/tests/unit_tests/components/builder.cpp
@@ -44,6 +44,7 @@ class GetLabelTextTest :
 
 vector<pair<string, tuple<string, bool, int>>> get_label_text_list = {
   {"...", make_tuple("abcd", true, 3)},
+  {"abc", make_tuple("abc", true, 3)},
   {"abc", make_tuple("abcdefgh", false, 3)},
   {"a...", make_tuple("abcdefgh", true, 4)},
   {"abcd...", make_tuple("abcdefgh", true, 7)},

--- a/tests/unit_tests/components/builder.cpp
+++ b/tests/unit_tests/components/builder.cpp
@@ -65,16 +65,4 @@ TEST_P(GetLabelTextTest, correctness) {
   EXPECT_LE(text.length(), m_label->m_maxlen) << "Returned text is longer than maxlen";
 }
 
-/**
- * \brief Tests, if get_label_text throws an exception, when ellipsis is
- *        turned on and m_maxlen is lower than 3 (length of the ellipsis)
- */
-TEST_F(GetLabelTextTest, throwsException) {
-  label_t m_label = factory_util::shared<label>("abcdef");
-  m_label->m_ellipsis = true;
-  m_label->m_maxlen = 2;
-
-  EXPECT_ANY_THROW(m_builder.get_label_text(m_label));
-}
-
 // }}}


### PR DESCRIPTION
As described in #1194 polybar never actually checks the m_ellipsis flag
in labels.

Right now, I have only refactored the builder to determine the actual
label text inside a function and added failing tests for that bug and
the general expected behaviour of get_label_text. This is why the
tests in the current build will fail.

This will probably decrease test coverage quite drastically, as codecov
doesn't track builder.cpp yet, so this basically adds a bunch of not
covered lines that codecov is now tracking

Also @NBonaparte, do you think the builder should throw an exception,
if the maxlen is less than the length of the ellipsis and ellipsis is
enabled, because it would be impossible to follow both the label-maxlen
and the label-ellipsis directive?

EDIT1: Seems like the new test doesn't build on travis, and for some reason the travis build doesn't fail when this happens.
EDIT2: I have fixed the compilation error, now the test should fail for the right reasons
EDIT3: Fixes #1194