### PR TITLE
fix(gcc): Fix -Wstringop-truncation warning

### DIFF
--- a/src/adapters/net.cpp
+++ b/src/adapters/net.cpp
@@ -159,7 +159,12 @@ namespace net {
     driver.cmd = ETHTOOL_GDRVINFO;
 
     memset(&request, 0, sizeof(request));
-    strncpy(request.ifr_name, m_interface.c_str(), IFNAMSIZ - 0);
+    
+    /*
+     * Only copy array size minus one bytes over to ensure there is a 
+     * terminating NUL byte (which is guaranteed by memset)
+     */
+    strncpy(request.ifr_name, m_interface.c_str(), IFNAMSIZ - 1);
 
     request.ifr_data = reinterpret_cast<caddr_t>(&driver);
 


### PR DESCRIPTION
As mentioned in #1215, gcc >=8 will complain, if strncpy truncates the
source string or gcc can prove there is no NUL terminating byte.

This also updates the i3ipcpp submodule where there was a similar error

Fixes #1215