### PR TITLE
refactor(ccache): Enable by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,23 @@
 #
 cmake_minimum_required(VERSION 3.1.0 FATAL_ERROR)
 
+# Enable ccache by default and as early as possible because project() performs
+# checks on the compiler
+option(ENABLE_CCACHE "Enable ccache support" ON)
+if(ENABLE_CCACHE)
+  message(STATUS "Trying to enable ccache")
+  find_program(BIN_CCACHE ccache)
+
+  string(ASCII 27 esc)
+  if(NOT BIN_CCACHE)
+    message(STATUS "${esc}[33mCouldn't locate ccache, disabling ccache...${esc}[0m")
+  else()
+    # Enable only if the binary is found
+    message(STATUS "${esc}[32mUsing compiler cache ${BIN_CCACHE}${esc}[0m")
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ${BIN_CCACHE})
+  endif()
+endif()
+
 project(polybar C CXX)
 
 set(CMAKE_MODULE_PATH

--- a/cmake/01-core.cmake
+++ b/cmake/01-core.cmake
@@ -37,7 +37,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
   # libinotify uses c99 extension, so suppress this error
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-c99-extensions")
   # Ensures that libraries from dependencies in LOCALBASE are used
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -L/usr/local/lib") 
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -L/usr/local/lib")
 endif()
 
 if(${CMAKE_CXX_COMPILER_ID} STREQUAL Clang)
@@ -79,12 +79,6 @@ if(CXXLIB_CLANG)
 elseif(CXXLIB_GCC)
   message_colored(STATUS "Linking against libstdc++" 32)
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lstdc++")
-endif()
-
-if(ENABLE_CCACHE)
-  querybin(ccache)
-  set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ${BINPATH_ccache})
-  set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ${BINPATH_ccache})
 endif()
 
 # Install paths

--- a/cmake/02-opts.cmake
+++ b/cmake/02-opts.cmake
@@ -23,7 +23,6 @@ option(CXXLIB_GCC "Link against stdlibc++" OFF)
 option(BUILD_IPC_MSG "Build ipc messager" ON)
 option(BUILD_TESTS "Build testsuite" OFF)
 
-option(ENABLE_CCACHE "Enable ccache support" OFF)
 option(ENABLE_ALSA "Enable alsa support" ON)
 option(ENABLE_CURL "Enable curl support" ON)
 option(ENABLE_I3 "Enable i3 support" ON)


### PR DESCRIPTION
Following [1] to get to this setup.

We setup all the ccache configuration before calling project() because
project will perform compiler checks. This is also why we can't use
message_colored here and print the colors manually

Before ENABLE_CCACHE was not yet defined when we reached the check in
01-core because the option was defined in 02-opts

[1] https://crascit.com/2016/04/09/using-ccache-with-cmake/