### PR TITLE
fix(travis): Crash

### DIFF
--- a/common/travis/install_xcb_xrm.sh
+++ b/common/travis/install_xcb_xrm.sh
@@ -1,9 +1,20 @@
 #!/bin/bash
-if [ -z "$(ls -A "${DEPS_DIR}/xcb-util-xrm" 2>/dev/null)" ]; then
+
+# Fail on error
+set -e
+
+# If the Makefile exists, we have already cached xrm
+if [ ! -e "${DEPS_DIR}/xcb-util-xrm/Makefile" ]; then
   git clone --recursive https://github.com/Airblader/xcb-util-xrm
-  cd xcb-util-xrm && {
-    ./autogen.sh --prefix=/usr --libdir=/usr/lib
-    make
-    sudo make install
-  }
 fi
+
+cd xcb-util-xrm
+
+# Install xrm on the system
+# If that doesn't work for some reason (not yet compiled, corrupt cache)
+# we compile xrm and try to install it again
+sudo make install || {
+  ./autogen.sh --prefix=/usr --libdir=/usr/lib
+  make
+  sudo make install
+}


### PR DESCRIPTION
For some reason some of the travis builds fail with the following compiler errors:
```
/home/travis/build/jaagr/polybar/src/main.cpp:68:65: error: incomplete type 'polybar::v3_1_0::connection' named in nested name specifier
      throw application_error("X connection error... (what: " + connection::error_str(xcb_error) + ")");
                                                                ^~~~~~~~~~~~
/home/travis/build/jaagr/polybar/include/x11/types.hpp:30:7: note: forward declaration of 'polybar::v3_1_0::connection'
class connection;
      ^
/home/travis/build/jaagr/polybar/src/main.cpp:71:22: error: incomplete type 'polybar::v3_1_0::connection' named in nested name specifier
    connection& conn{connection::make(xcb_connection, xcb_screen)};
                     ^~~~~~~~~~~~
/home/travis/build/jaagr/polybar/include/x11/types.hpp:30:7: note: forward declaration of 'polybar::v3_1_0::connection'
class connection;
      ^
/home/travis/build/jaagr/polybar/src/main.cpp:72:9: error: member access into incomplete type 'polybar::v3_1_0::connection'
    conn.ensure_event_mask(conn.root(), XCB_EVENT_MASK_PROPERTY_CHANGE);
        ^
/home/travis/build/jaagr/polybar/include/x11/types.hpp:30:7: note: forward declaration of 'polybar::v3_1_0::connection'
class connection;
      ^
/home/travis/build/jaagr/polybar/src/main.cpp:78:25: error: use of undeclared identifier 'randr_util'
      for (auto&& mon : randr_util::get_monitors(conn, conn.root(), true)) {
                        ^
/home/travis/build/jaagr/polybar/src/main.cpp:78:60: error: member access into incomplete type 'polybar::v3_1_0::connection'
      for (auto&& mon : randr_util::get_monitors(conn, conn.root(), true)) {
                                                           ^
/home/travis/build/jaagr/polybar/include/x11/types.hpp:30:7: note: forward declaration of 'polybar::v3_1_0::connection'
class connection;
      ^
```

From what I can tell, the only difference between builds that fail and builds that don't, is that the failing builds have the `xcb-xrm` option disabled.

**EDIT1:**
I have been able to reproduce this locally with the `-DWITH_XRM=OFF` cmake option. On travis the [`install_xcb_xrm.sh`](https://github.com/jaagr/polybar/blob/master/common/travis/install_xcb_xrm.sh) file somehow thinks that the xrm binaries were cached and thus the script doesn't run. However a failed build when xrm is disabled shouldn't happen anyways, so these are two separate problems.

**EDIT2:**
Looks like in commit 20f3d9a1419ea3cbf5694d442847eccb4c8f148c the headers I removed that I thought weren't necessary anymore because of forward declaration, are actually necessary