### PR TITLE
New config parser

### DIFF
--- a/.ycm_extra_conf.py
+++ b/.ycm_extra_conf.py
@@ -116,7 +116,7 @@ def FlagsForFile(filename, **kwargs):
     # Bear in mind that compilation_info.compiler_flags_ does NOT return a
     # python list, but a "list-like" StringVec object
     final_flags = MakeRelativePathsInFlagsAbsolute(
-        compilation_info.compiler_flags_,
+        [x for x in compilation_info.compiler_flags_ if x != "-Werror"],
         compilation_info.compiler_working_dir_)
   else:
     # We use default flags if GetCompilationInfoForFile can't find any flags

--- a/include/components/config_parser.hpp
+++ b/include/components/config_parser.hpp
@@ -1,0 +1,262 @@
+#pragma once
+
+#include <algorithm>
+#include <unordered_map>
+
+#include "common.hpp"
+#include "errors.hpp"
+#include "components/logger.hpp"
+#include "utils/file.hpp"
+#include "utils/string.hpp"
+
+POLYBAR_NS
+
+/**
+ * \brief Generic exception for the config_parser
+ */
+DEFINE_ERROR(parser_error);
+
+/**
+ * \brief Exception object for syntax errors
+ *
+ * Contains filepath and line number where syntax error was found
+ */
+class syntax_error : public parser_error {
+
+  public:
+    /**
+     * Default values are used when the thrower doesn't know the position.
+     * parse_line has to catch, set the proper values and rethrow
+     */
+    syntax_error(string msg, string file = "", int line_no = -1)
+      : parser_error(msg), file(file), line_no(line_no), msg(msg) {}
+
+    virtual const char* what() const throw() {
+      return ("Syntax error at " + file + ":" + to_string(line_no) + " " + msg).c_str();
+    }
+
+  private:
+    string file;
+    int line_no;
+    string msg;
+};
+
+/**
+ * \enum line_type
+ * \brief All different types a line in a config can be
+ */
+enum line_type {KEY, HEADER, COMMENT, EMPTY, UNKNOWN};
+
+/**
+ * \struct line_t
+ * \brief Storage for a single config line
+ *
+ * More sanitized than the actual string of the comment line, with information
+ * about line type and structure
+ */
+struct line_t {
+  string header;
+  string key_value[2];
+
+  /**
+   * Whether or not this struct contains a valid line
+   * If false all other fields are not set
+   * Set this to false, if you want to return a line that has no effect
+   * (for example when you parse a comment line), do not use this to signal
+   * any kind of error, throw an exception instead
+   */
+  bool is_valid;
+
+  /**
+   * Index of the config_parser::files vector where this line is from
+   */
+  int file_index;
+  int line_no;
+
+  /**
+   * We access header, if is_header == true otherwise we access key_value
+   */
+  bool is_header;
+};
+
+using valuemap_t = std::unordered_map<string, string>;
+using sectionmap_t = std::map<string, valuemap_t>;
+using file_list = vector<string>;
+
+/**
+ * \brief Represents the whole configuration the user has given
+ */
+struct config_file {
+  /**
+   * Maps sections to a list of its key-value pairs
+   */
+  sectionmap_t sections;
+
+  /**
+   * Full path to the config file
+   */
+  string filename;
+
+  /**
+   * All files included by the config (not including itself)
+   *
+   */
+  file_list included;
+};
+
+class config_parser {
+  public:
+
+    config_parser(const logger& logger, string&& file);
+
+    /**
+     * \brief Performs the parsing of the main config file
+     *
+     * Goes through multiple steps:
+     * - Reads and parses all the lines in the config file while resolving
+     *   include-file directives and detecting cyclic dependencies in those
+     *   directives.
+     * - Builds a graph. The nodes are key value pairs and (u, v) is an edge,
+     *   when the value of u references v (via ${section.key} and the like)
+     * - The topological order is calculated. If that is not possible, there
+     *   are cyclic dependencies in the config and it is not valid. We reverse
+     *   the topological order, traverse the nodes in that order and
+     *   dereference all references. In the end no valid ${...} references
+     *   should be left.
+     * - Builds a second graph. The nodes are sections and (u, v) is and edge,
+     *   iff u has an inherit key that points to v.
+     * - The topological order of this second graph is calculated and all
+     *   sections without an inherit key are ignored.
+     * - The topological order is reversed, the sections are traversed in
+     *   that order, and the keys of the inherited sections are pulled in.
+     *   Here, there shouldn't be any inherit keys left.
+     * - Finally the data is put into a sectionmap_t
+     *
+     * \returns config_file struct containing a
+     *          section <-> list of key-value pair mapping for the caller to
+     *          be used. All references in the value strings will already have
+     *          been resolved and can be used without further processing.
+     *
+     * \throws syntax_error If there was any kind of syntax error
+     * \throws parser_error If aynthing else went wrong
+     */
+    config_file parse();
+
+  protected:
+
+    /**
+     * \brief Parses the given file and extracts key-value pairs and section
+     *        headers and adds them onto the `lines` vector
+     *
+     * This method directly resolves `include-file` directives and checks for
+     * cyclic dependencies
+     *
+     * It is assumed the file exists
+     */
+    void parse_file(string file, file_list path);
+
+    /**
+     * \brief Parses the given line string which occurs in files[file_index] on line
+     *        line_no and creates a line_t struct
+     *
+     * We use the INI file syntax (https://en.wikipedia.org/wiki/INI_file);
+     * Whitespaces (tested with isspace()) at the beginning and end of a line are ignored
+     * Keys and section names can contain any character except for the following:
+     * - spaces
+     * - equal sign (=)
+     * - semicolon (;)
+     * - pound sign (#)
+     * - Any kind of parentheses ([](){})
+     * - colon (:)
+     * - period (.)
+     * - dollar sign ($)
+     * - backslash (\)
+     * - percent sign (%)
+     * - single and double quotes ('")
+     * So basically any character that has any kind of special meaning is prohibited.
+     *
+     * Comment lines have to start with a semicolon (;) or a pound sign (#),
+     * you cannot put a comment after another type of line.
+     *
+     * key and section names are case-sensitive.
+     *
+     * Keys are specified as `key = value`, spaces around the equal sign, as
+     * well as double quotes around the value are ignored
+     *
+     * sections are defined as [section], everything inside the square brackets is part of the name
+     *
+     * \throws syntax_error if the line isn't well formed
+     */
+    line_t parse_line(int file_index, int line_no, string line);
+
+    /**
+     * \brief Deterimes the type of a line read from a config file
+     *
+     * This only looks at the first character and doesn't check if the line is
+     * actually syntactically correct.
+     * HEADER ('['), COMMENT (';' or '#') and EMPTY (None) are uniquely
+     * identified by their first character (or lack thereof). Any line that
+     * is none of the above and contains an equal sign, is treated as KEY.
+     * All others are UNKNOWN
+     */
+    line_type get_line_type(string line);
+
+    /**
+     * \brief Parse a line containing a section header and returns the header name
+     *
+     * Only assumes that the line starts with '[' and is trimmed
+     *
+     * \throws syntax_error if the line doesn't end with ']' or the header name
+     *         contains forbidden characters
+     */
+    string parse_header(string line);
+
+    /**
+     * \brief Parses a line containing a key-value pair and returns the key name
+     *        and the value string inside a std::pair
+     *
+     * Only assumes that the line contains '=' at least once and is trimmed
+     *
+     * \throws syntax_error if the key contains forbidden characters
+     */
+    std::pair<string, string> parse_key(string line);
+
+  private:
+
+    /**
+     * \brief Checks if the given name doesn't contain any spaces or characters
+     *        in config_parser::forbidden_chars
+     */
+    bool is_valid_name(string name);
+
+    const logger& m_log;
+
+    /**
+     * \brief Full path to the main config file
+     */
+    string m_file;
+
+    /**
+     * \brief Name of all the files the config includes values from
+     *
+     * The line_t struct uses indices to this vector to map lines to their
+     * original files. This allows us to point the user to the exact location
+     * of errors
+     */
+    file_list files;
+
+    /*
+     * \brief List of all the lines in the config (with included files)
+     *
+     * The order here matters, as we have not yet associated key-value pairs
+     * with sections
+     */
+    vector<line_t> lines;
+
+    /*
+     * \brief None of these characters can be used in the key and section names
+     */
+    static constexpr auto forbidden_chars = "\"'=;#[](){}:.$\\%";
+};
+
+POLYBAR_NS_END

--- a/src/components/config_parser.cpp
+++ b/src/components/config_parser.cpp
@@ -1,0 +1,43 @@
+#include "components/config_parser.hpp"
+
+POLYBAR_NS
+
+config_parser::config_parser(const logger& logger, string&& file)
+  : m_log(logger), m_file(forward<string>(file)) {
+
+    if (!file_util::exists(m_file)) {
+      throw application_error("Could not find config file: " + m_file);
+    }
+
+    m_log.trace("Parsing config file: %s", m_file);
+
+  }
+
+config_file parse() {
+  return {};
+}
+
+void config_parser::parse_file(string file, file_list path) {
+}
+
+line_t config_parser::parse_line(int file_index, int line_no, string line) {
+  return {};
+}
+
+line_type config_parser::get_line_type(string line) {
+  return line_type::UNKNOWN;
+}
+
+string config_parser::parse_header(string line) {
+  return "";
+}
+
+std::pair<string, string> config_parser::parse_key(string line) {
+  return {"", ""};
+}
+
+bool config_parser::is_valid_name(string name) {
+  return false;
+}
+
+POLYBAR_NS_END

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,6 +35,10 @@ add_subdirectory(${CMAKE_BINARY_DIR}/googletest-src
 
 # }}}
 
+# Disable errors for warnings so that we can run tests even with some warnings
+string(REGEX REPLACE "-Werror[^ ]*" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+string(REPLACE "-pedantic-errors" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+
 function(unit_test file tests)
   set(multi_value_args SOURCES)
 
@@ -62,12 +66,17 @@ function(unit_test file tests)
 endfunction()
 
 unit_test(utils/color unit_tests)
+
 unit_test(utils/math unit_tests)
+
 unit_test(utils/memory unit_tests)
+
 unit_test(utils/scope unit_tests)
+
 unit_test(utils/string unit_tests
   SOURCES
   utils/string.cpp)
+
 unit_test(utils/file unit_tests
   SOURCES
   utils/command.cpp
@@ -82,6 +91,7 @@ unit_test(components/command_line unit_tests
   SOURCES
   components/command_line.cpp
   utils/string.cpp)
+
 unit_test(components/bar unit_tests)
 
 # Compile all unit tests with 'make all_unit_tests'

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -94,5 +94,14 @@ unit_test(components/command_line unit_tests
 
 unit_test(components/bar unit_tests)
 
+unit_test(components/config_parser unit_tests
+  SOURCES
+  components/config_parser.cpp
+  utils/string.cpp
+  utils/file.cpp
+  utils/env.cpp
+  utils/concurrency.cpp
+  components/logger.cpp)
+
 # Compile all unit tests with 'make all_unit_tests'
 add_custom_target("all_unit_tests" DEPENDS ${unit_tests})

--- a/tests/unit_tests/components/config_parser.cpp
+++ b/tests/unit_tests/components/config_parser.cpp
@@ -1,0 +1,166 @@
+#include <algorithm>
+
+#include "common/test.hpp"
+#include "components/config_parser.hpp"
+#include "components/logger.hpp"
+
+using namespace polybar;
+using namespace std;
+
+/**
+ * \brief Testing-only subclass of config_parser to change access level
+ */
+class TestableConfigParser : public config_parser {
+  using config_parser::config_parser;
+  public: using config_parser::get_line_type;
+  public: using config_parser::parse_key;
+  public: using config_parser::parse_header;
+};
+
+/**
+ * \brief Fixture class
+ */
+class ConfigParser : public ::testing::Test {
+  protected:
+    unique_ptr<TestableConfigParser> parser = make_unique<TestableConfigParser>(logger(loglevel::NONE), "/dev/zero");
+};
+
+// ParseLineTest {{{
+
+// }}}
+
+// GetLineTypeTest {{{
+
+/**
+ * \brief Class for parameterized tests on get_line_type
+ *
+ * Parameters are pairs of the expected line type and a string that should be
+ * detected as that line type
+ */
+class GetLineTypeTest :
+  public ConfigParser,
+  public ::testing::WithParamInterface<pair<line_type, string>> {
+  };
+
+/**
+ * \brief Helper function generate GetLineTypeTest parameter values
+ */
+vector<pair<line_type, string>> line_type_transform(vector<string> in, line_type type) {
+  vector<pair<line_type, string>> out;
+
+  for (auto i : in) {
+    out.emplace_back(type, i);
+  }
+
+  return out;
+}
+
+
+/**
+ * \brief Parameter values for GetLineTypeTest
+ */
+auto line_type_key = line_type_transform({"a = b", "  a =b", " a\t =\t \t b", "a = "}, line_type::KEY);
+auto line_type_header = line_type_transform({"[section]", " [section]", "[section/sub]"}, line_type::HEADER);
+auto line_type_comment = line_type_transform({";abc", "#abc", "\t;abc", " #abc", "\t \t;abc"}, line_type::COMMENT);
+auto line_type_empty = line_type_transform({"", " ", "\t" "   \t  \t"}, line_type::EMPTY);
+auto line_type_unknown = line_type_transform({"|a", " |a", "a"}, line_type::UNKNOWN);
+
+/**
+ * Instantiate GetLineTypeTest for the different line types
+ */
+INSTANTIATE_TEST_CASE_P(LineTypeKey, GetLineTypeTest, ::testing::ValuesIn(line_type_key),);
+INSTANTIATE_TEST_CASE_P(LineTypeHeader, GetLineTypeTest, ::testing::ValuesIn(line_type_header),);
+INSTANTIATE_TEST_CASE_P(LineTypeComment, GetLineTypeTest, ::testing::ValuesIn(line_type_comment),);
+INSTANTIATE_TEST_CASE_P(LineTypeEmpty, GetLineTypeTest, ::testing::ValuesIn(line_type_empty),);
+INSTANTIATE_TEST_CASE_P(LineTypeUnknown, GetLineTypeTest, ::testing::ValuesIn(line_type_unknown),);
+
+/**
+ * \brief Parameterized test for get_line_type
+ */
+TEST_P(GetLineTypeTest, correctness) {
+  EXPECT_EQ(GetParam().first, parser->get_line_type(GetParam().second));
+}
+
+// }}}
+
+// ParseKeyTest {{{
+
+/**
+ * \brief Class for parameterized tests on parse_key
+ *
+ * The first element of the pair is the expected key-value pair and the second
+ * element is the string to be parsed, has to be trimmed and valid.
+ */
+class ParseKeyTest :
+  public ConfigParser,
+  public ::testing::WithParamInterface<pair<pair<string, string>, string>> {};
+
+
+vector<pair<pair<string, string>, string>> parse_key_list = {
+  {{"key", "value"}, "key = value"},
+  {{"key", "value"}, "key=value"},
+  {{"key", "value"}, "key =\"value\""},
+  {{"key", "value"}, "key\t=\t \"value\""},
+  {{"key", "\"value"}, "key = \"value"},
+  {{"key", "value\""}, "key = value\""},
+  {{"key", "= value"}, "key == value"},
+  {{"key", ""}, "key ="},
+  {{"key", ""}, "key =\"\""},
+};
+
+INSTANTIATE_TEST_CASE_P(Inst, ParseKeyTest,
+    ::testing::ValuesIn(parse_key_list),);
+
+/**
+ * Parameterized test for parse_key with valid line
+ */
+TEST_P(ParseKeyTest, correctness) {
+  EXPECT_EQ(GetParam().first, parser->parse_key(GetParam().second));
+}
+
+/**
+ * Tests if exception is thrown for invalid key line
+ */
+TEST_F(ParseKeyTest, throwsSyntaxError) {
+  EXPECT_THROW(parser->parse_key("forbidden char = value"), syntax_error);
+  EXPECT_THROW(parser->parse_key("forbidden\tchar = value"), syntax_error);
+}
+// }}}
+
+// ParseHeaderTest {{{
+
+/**
+ * \brief Class for parameterized tests on parse_key
+ *
+ * The first element of the pair is the expected key-value pair and the second
+ * element is the string to be parsed, has to be trimmed and valid
+ */
+class ParseHeaderTest :
+  public ConfigParser,
+  public ::testing::WithParamInterface<pair<string, string>> {};
+
+vector<pair<string, string>> parse_header_list = {
+  {"section", "[section]"},
+  {"bar/name", "[bar/name]"},
+  {"with_underscore", "[with_underscore]"},
+};
+
+INSTANTIATE_TEST_CASE_P(Inst, ParseHeaderTest,
+    ::testing::ValuesIn(parse_header_list),);
+
+/**
+ * Parameterized test for parse_header with valid line
+ */
+TEST_P(ParseHeaderTest, correctness) {
+  EXPECT_EQ(GetParam().first, parser->parse_header(GetParam().second));
+}
+
+/**
+ * Tests if exception is thrown for invalid header line
+ */
+TEST_F(ParseHeaderTest, throwsSyntaxError) {
+  EXPECT_THROW(parser->parse_header("[no_end"), syntax_error);
+  EXPECT_THROW(parser->parse_header("[forbidden char]"), syntax_error);
+  EXPECT_THROW(parser->parse_header("[forbidden\tchar]"), syntax_error);
+}
+// }}}


### PR DESCRIPTION
I have taken the first step to implement a new config parser. For now it's
only a skeleton. But it should help fix a bunch of issues and make the
parser as well as the dependency checking for variable references as well as
included files much more robust

It will also support giving more helpful error messages for syntax errors, I
think the current implementationn doesn't say anything about syntax errors.

Will add more info later with what my plans are

Should
Fix #412
Fix #783
Fix #954

And make the following obsolte:
Closes #1032
Closes #784

It should also make it easier to add an inotify watch onto included files,
as described in #675