### PR TITLE
Teach net module how to query an IPv6 address.

### DIFF
--- a/include/adapters/net.hpp
+++ b/include/adapters/net.hpp
@@ -14,6 +14,7 @@
 #include "common.hpp"
 #include "settings.hpp"
 #include "errors.hpp"
+#include "components/logger.hpp"
 #include "utils/math.hpp"
 
 POLYBAR_NS
@@ -78,9 +79,11 @@ namespace net {
     string format_speedrate(float bytes_diff, int minwidth) const;
     void query_ip6();
 
+    const logger& m_log;
     unique_ptr<file_descriptor> m_socketfd;
     link_status m_status{};
     string m_interface;
+    string m_ip6_last_error{};
     bool m_tuntap{false};
     bool m_unknown_up{false};
   };

--- a/include/adapters/net.hpp
+++ b/include/adapters/net.hpp
@@ -83,7 +83,6 @@ namespace net {
     unique_ptr<file_descriptor> m_socketfd;
     link_status m_status{};
     string m_interface;
-    string m_ip6_last_error{};
     bool m_tuntap{false};
     bool m_unknown_up{false};
   };

--- a/include/adapters/net.hpp
+++ b/include/adapters/net.hpp
@@ -49,6 +49,7 @@ namespace net {
 
   struct link_status {
     string ip;
+    string ip6;
     link_activity previous{};
     link_activity current{};
   };
@@ -66,6 +67,7 @@ namespace net {
     virtual bool ping() const;
 
     string ip() const;
+    string ip6() const;
     string downspeed(int minwidth = 3) const;
     string upspeed(int minwidth = 3) const;
     void set_unknown_up(bool unknown = true);
@@ -74,6 +76,7 @@ namespace net {
     void check_tuntap();
     bool test_interface() const;
     string format_speedrate(float bytes_diff, int minwidth) const;
+    void query_ip6();
 
     unique_ptr<file_descriptor> m_socketfd;
     link_status m_status{};

--- a/src/adapters/net.cpp
+++ b/src/adapters/net.cpp
@@ -107,6 +107,7 @@ namespace net {
 
     try {
       this->query_ip6();
+      m_ip6_last_error.clear();
     } catch (const network_error& err) {
       if (m_ip6_last_error != err.what()) {
         m_ip6_last_error = err.what();

--- a/src/adapters/net.cpp
+++ b/src/adapters/net.cpp
@@ -148,10 +148,12 @@ namespace net {
     }
 
     if (connect(fd, (const sockaddr*)&a, l) == -1) {
+      close(fd);
       throw network_error("connect() " + string(strerror(errno)));
     }
 
     if (getsockname(fd, (struct sockaddr*)&a, &l) == -1) {
+      close(fd);
       throw network_error("getsockname() " + string(strerror(errno)));
     }
 

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -117,6 +117,7 @@ namespace modules {
       label->reset_tokens();
       label->replace_token("%ifname%", m_interface);
       label->replace_token("%local_ip%", network->ip());
+      label->replace_token("%local_ip6%", network->ip6());
       label->replace_token("%upspeed%", upspeed);
       label->replace_token("%downspeed%", downspeed);
 


### PR DESCRIPTION
This should probably throw network_error instead of call `perror()` maybe?

Also, I think if you lose addressing but the interface is still up, the value on m_status isn't unset so the address is still displayed. I think the IPv4 thingy does that too.

I'm also not sure if this works on FreeBSD.

EDIT: Fixes #1234