### PR TITLE
Convert tests to gtest

### DIFF
--- a/tests/unit_tests/utils/color.cpp
+++ b/tests/unit_tests/utils/color.cpp
@@ -1,73 +1,71 @@
 #include "common/test.hpp"
 #include "utils/color.hpp"
 
-int main() {
-  using namespace polybar;
+using namespace polybar;
 
-  "rgb"_test = []{
-    unsigned int color{0x123456};
-    expect(color_util::alpha_channel<unsigned char>(color) == 0);
-    expect(color_util::red_channel<unsigned char>(color) == 0x12);
-    expect(color_util::green_channel<unsigned char>(color) == 0x34);
-    expect(color_util::green_channel<unsigned short int>(color) == 0x3434);
-    expect(color_util::blue_channel<unsigned char>(color) == 0x56);
+TEST(String, rgb) {
+  unsigned int color{0x123456};
+  EXPECT_EQ(0, color_util::alpha_channel<unsigned char>(color));
+  EXPECT_EQ(0x12, color_util::red_channel<unsigned char>(color));
+  EXPECT_EQ(0x34, color_util::green_channel<unsigned char>(color));
+  EXPECT_EQ(0x3434, color_util::green_channel<unsigned short int>(color));
+  EXPECT_EQ(0x56, color_util::blue_channel<unsigned char>(color));
 
-    expect(rgb{0xFF112233}.b == 0x33 / 255.0);
-    expect(rgb{0x88449933}.g == 0x51 / 255.0);
-    expect(rgb{0xee111111} == 0xff0f0f0f);
-    expect(rgb{0x99112233} == 0xff0a141e);
-  };
+  EXPECT_TRUE(0x33 / 255.0 == rgb{0xFF112233}.b);
+  EXPECT_TRUE(0x51 / 255.0 == rgb{0x88449933}.g);
+  EXPECT_TRUE(0xff0f0f0f == rgb{0xee111111});
+  EXPECT_TRUE(0xff0a141e == rgb{0x99112233});
+}
 
-  "rgba"_test = []{
-    unsigned int color{0xCC123456};
-    expect(color_util::alpha_channel<unsigned short int>(color) == 0xCCCC);
-    expect(color_util::red_channel<unsigned short int>(color) == 0x1212);
-    expect(color_util::red_channel<unsigned char>(color) == 0x12);
-    expect(color_util::green_channel<unsigned short int>(color) == 0x3434);
-    expect(color_util::blue_channel<unsigned short int>(color) == 0x5656);
+TEST(String, rgba) {
+  unsigned int color{0xCC123456};
+  EXPECT_EQ(0xCCCC, color_util::alpha_channel<unsigned short int>(color));
+  EXPECT_EQ(0x1212, color_util::red_channel<unsigned short int>(color));
+  EXPECT_EQ(0x12, color_util::red_channel<unsigned char>(color));
+  EXPECT_EQ(0x3434, color_util::green_channel<unsigned short int>(color));
+  EXPECT_EQ(0x5656, color_util::blue_channel<unsigned short int>(color));
 
-    expect(rgba{0xCC112233}.a == 0xCC / 255.0);
-    expect(rgba{0x88449933}.g == 0x99 / 255.0);
-    expect(static_cast<unsigned int>(rgba{0xFF111111}) == 0xFF111111);
-    expect(static_cast<unsigned int>(rgba{0x00FFFFFF}) == 0x00FFFFFF);
-  };
+  EXPECT_EQ(0xCC / 255.0, rgba{0xCC112233}.a);
+  EXPECT_EQ(0x99 / 255.0, rgba{0x88449933}.g);
+  EXPECT_EQ(0xFF111111, static_cast<unsigned int>(rgba{0xFF111111}));
+  EXPECT_EQ(0x00FFFFFF, static_cast<unsigned int>(rgba{0x00FFFFFF}));
+}
 
-  "hex"_test = [] {
-    unsigned int colorA{0x123456};
-    expect(color_util::hex<unsigned char>(colorA) == "#123456"s);
-    unsigned int colorB{0xCC123456};
-    expect(color_util::hex<unsigned short int>(colorB) == "#cc123456"s);
-    unsigned int colorC{0x00ffffff};
-    expect(color_util::hex<unsigned short int>(colorC) == "#00ffffff"s);
-  };
+TEST(String, hex) {
+  unsigned int colorA{0x123456};
+  EXPECT_EQ("#123456"s, color_util::hex<unsigned char>(colorA));
+  unsigned int colorB{0xCC123456};
+  EXPECT_EQ("#cc123456"s, color_util::hex<unsigned short int>(colorB));
+  unsigned int colorC{0x00ffffff};
+  EXPECT_EQ("#00ffffff"s, color_util::hex<unsigned short int>(colorC));
+}
 
-  "parse_hex"_test = [] {
-    expect(color_util::parse_hex("#fff") == "#ffffffff");
-    expect(color_util::parse_hex("#123") == "#ff112233");
-    expect(color_util::parse_hex("#888888") == "#ff888888");
-    expect(color_util::parse_hex("#00aa00aa") == "#00aa00aa");
-  };
+TEST(String, parseHex) {
+  EXPECT_EQ("#ffffffff", color_util::parse_hex("#fff"));
+  EXPECT_EQ("#ff112233", color_util::parse_hex("#123"));
+  EXPECT_EQ("#ff888888", color_util::parse_hex("#888888"));
+  EXPECT_EQ("#00aa00aa", color_util::parse_hex("#00aa00aa"));
+}
 
-  "parse"_test = [] {
-    expect(color_util::parse("invalid") == 0);
-    expect(color_util::parse("#f") == 0);
-    expect(color_util::parse("#ff") == 0);
-    expect(color_util::parse("invalid", 0xFF999999) == 0xFF999999);
-    expect(color_util::parse("invalid", 0x00111111) == 0x00111111);
-    expect(color_util::parse("invalid", 0xFF000000) == 0xFF000000);
-    expect(color_util::parse("#fff") == 0xffffffff);
-    expect(color_util::parse("#890") == 0xFF889900);
-    expect(color_util::parse("#55888777") == 0x55888777);
-    expect(color_util::parse("#88aaaaaa") == 0x88aaaaaa);
-    expect(color_util::parse("#00aaaaaa") == 0x00aaaaaa);
-    expect(color_util::parse("#00FFFFFF") == 0x00FFFFFF);
-  };
+TEST(String, parse) {
+  EXPECT_EQ(0, color_util::parse("invalid"));
+  EXPECT_EQ(0, color_util::parse("#f"));
+  EXPECT_EQ(0, color_util::parse("#ff"));
+  EXPECT_EQ(0xFF999999, color_util::parse("invalid", 0xFF999999));
+  EXPECT_EQ(0x00111111, color_util::parse("invalid", 0x00111111));
+  EXPECT_EQ(0xFF000000, color_util::parse("invalid", 0xFF000000));
+  EXPECT_EQ(0xffffffff, color_util::parse("#fff"));
+  EXPECT_EQ(0xFF889900, color_util::parse("#890"));
+  EXPECT_EQ(0x55888777, color_util::parse("#55888777"));
+  EXPECT_EQ(0x88aaaaaa, color_util::parse("#88aaaaaa"));
+  EXPECT_EQ(0x00aaaaaa, color_util::parse("#00aaaaaa"));
+  EXPECT_EQ(0x00FFFFFF, color_util::parse("#00FFFFFF"));
+}
 
-  "simplify"_test = [] {
-    expect(color_util::simplify_hex("#FF111111") == "#111");
-    expect(color_util::simplify_hex("#ff223344") == "#234");
-    expect(color_util::simplify_hex("#ee223344") == "#ee223344");
-    expect(color_util::simplify_hex("#ff234567") == "#234567");
-    expect(color_util::simplify_hex("#00223344") == "#00223344");
-  };
+TEST(String, simplify) {
+  EXPECT_EQ("#111", color_util::simplify_hex("#FF111111"));
+  EXPECT_EQ("#234", color_util::simplify_hex("#ff223344"));
+  EXPECT_EQ("#ee223344", color_util::simplify_hex("#ee223344"));
+  EXPECT_EQ("#234567", color_util::simplify_hex("#ff234567"));
+  EXPECT_EQ("#00223344", color_util::simplify_hex("#00223344"));
 }

--- a/tests/unit_tests/utils/file.cpp
+++ b/tests/unit_tests/utils/file.cpp
@@ -5,12 +5,13 @@
 #include "utils/command.hpp"
 #include "utils/file.hpp"
 
-int main() {
-  using namespace polybar;
+using namespace polybar;
 
-  "expand"_test = [] {
-    auto cmd = command_util::make_command("echo $HOME");
-    cmd->exec();
-    cmd->tail([](string home) { expect(file_util::expand("~/test") == home + "/test"); });
-  };
+TEST(File, expand) {
+  auto cmd = command_util::make_command("echo $HOME");
+  cmd->exec();
+  cmd->tail([](string home) {
+      EXPECT_EQ(home + "/test", file_util::expand("~/test"));
+      });
 }
+

--- a/tests/unit_tests/utils/math.cpp
+++ b/tests/unit_tests/utils/math.cpp
@@ -1,78 +1,76 @@
 #include "common/test.hpp"
 #include "utils/math.hpp"
 
-int main() {
-  using namespace polybar;
+using namespace polybar;
 
-  "min"_test = [] {
-    expect(math_util::min<int>(2, 5) == 2);
-    expect(math_util::min<int>(-8, -50) == -50);
-    expect(math_util::min<unsigned char>(0, -5) == 0);
-  };
+TEST(Math, min) {
+  EXPECT_EQ(2, math_util::min<int>(2, 5));
+  EXPECT_EQ(-50, math_util::min<int>(-8, -50));
+  EXPECT_EQ(0, math_util::min<unsigned char>(0, -5));
+}
 
-  "min"_test = [] {
-    expect(math_util::max<int>(2, 5) == 5);
-    expect(math_util::max<int>(-8, -50) == -8);
-    expect(math_util::max<unsigned char>(0, (1 << 8) - 5));
-  };
+TEST(Math, max) {
+  EXPECT_EQ(5, math_util::max<int>(2, 5));
+  EXPECT_EQ(-8, math_util::max<int>(-8, -50));
+  EXPECT_EQ(251, math_util::max<unsigned char>(0, (1 << 8) - 5));
+}
 
-  "cap"_test = [] {
-    expect(math_util::cap<int>(8, 0, 10) == 8);
-    expect(math_util::cap<int>(-8, 0, 10) == 0);
-    expect(math_util::cap<int>(15, 0, 10) == 10);
-    expect(math_util::cap<float>(20.5f, 0.0f, 30.0f) == 20.5f);
-    expect(math_util::cap<float>(1.0f, 0.0f, 2.0f) == 1.0f);
-    expect(math_util::cap<float>(-2.0f, -5.0f, 5.0f) == -2.0f);
-    expect(math_util::cap<float>(1.0f, 0.0f, 0.0f) == 0);
-  };
+TEST(Math, cap) {
+  EXPECT_EQ(8, math_util::cap<int>(8, 0, 10));
+  EXPECT_EQ(0, math_util::cap<int>(-8, 0, 10));
+  EXPECT_EQ(10, math_util::cap<int>(15, 0, 10));
+  EXPECT_EQ(20.5f, math_util::cap<float>(20.5f, 0.0f, 30.0f));
+  EXPECT_EQ(1.0f, math_util::cap<float>(1.0f, 0.0f, 2.0f));
+  EXPECT_EQ(-2.0f, math_util::cap<float>(-2.0f, -5.0f, 5.0f));
+  EXPECT_EQ(0, math_util::cap<float>(1.0f, 0.0f, 0.0f));
+}
 
-  "percentage"_test = [] {
-    expect(math_util::percentage<float, float>(5.5f, 0.0f, 10.0f) == 55.0f);
-    expect(math_util::percentage<float, int>(5.55f, 0.0f, 10.0f) == 56);
-    expect(math_util::percentage<float, float>(5.25f, 0.0f, 12.0f) == 43.75f);
-    expect(math_util::percentage<int, int>(5, 0, 12) == 41);
-    expect(math_util::percentage<float, float>(20.5f, 0.0f, 100.0f) == 20.5f);
-    expect(math_util::percentage<float, float>(4.5f, 1.0f, 6.0f) == 70.0f);
-    expect(math_util::percentage<float, int>(20.5f, 0.0f, 100.0f) == 21);
-    expect(math_util::percentage<int, int>(4, 2, 6) == 50);
-    expect(math_util::percentage<int, int>(0, -10, 10) == 50);
-    expect(math_util::percentage<int, int>(-10, -10, 10) == 0);
-    expect(math_util::percentage<int, int>(10, -10, 10) == 100);
-    expect(math_util::percentage(10, 0, 100) == 10);
-  };
+TEST(Math, percentage) {
+  EXPECT_EQ(55.0f, (math_util::percentage<float, float>(5.5f, 0.0f, 10.0f)));
+  EXPECT_EQ(56, (math_util::percentage<float, int>(5.55f, 0.0f, 10.0f)));
+  EXPECT_EQ(43.75f, (math_util::percentage<float, float>(5.25f, 0.0f, 12.0f)));
+  EXPECT_EQ(41, (math_util::percentage<int, int>(5, 0, 12)));
+  EXPECT_EQ(20.5f, (math_util::percentage<float, float>(20.5f, 0.0f, 100.0f)));
+  EXPECT_EQ(70.0f, (math_util::percentage<float, float>(4.5f, 1.0f, 6.0f)));
+  EXPECT_EQ(21, (math_util::percentage<float, int>(20.5f, 0.0f, 100.0f)));
+  EXPECT_EQ(50, (math_util::percentage<int, int>(4, 2, 6)));
+  EXPECT_EQ(50, (math_util::percentage<int, int>(0, -10, 10)));
+  EXPECT_EQ(0, (math_util::percentage<int, int>(-10, -10, 10)));
+  EXPECT_EQ(100, (math_util::percentage<int, int>(10, -10, 10)));
+  EXPECT_EQ(10, (math_util::percentage(10, 0, 100)));
+}
 
-  "percentage_to_value"_test = [] {
-    expect(math_util::percentage_to_value(50, 5) == 3);
-    expect(math_util::percentage_to_value<int, float>(50, 5) == 2.5f);
-    expect(math_util::percentage_to_value(0, 5) == 0);
-    expect(math_util::percentage_to_value(10, 5) == 1);
-    expect(math_util::percentage_to_value(20, 5) == 1);
-    expect(math_util::percentage_to_value(30, 5) == 2);
-    expect(math_util::percentage_to_value(40, 5) == 2);
-    expect(math_util::percentage_to_value(50, 5) == 3);
-    expect(math_util::percentage_to_value(100, 5) == 5);
-    expect(math_util::percentage_to_value(200, 5) == 5);
-    expect(math_util::percentage_to_value(-30, 5) == 0);
-  };
+TEST(Math, percentageToValue) {
+  EXPECT_EQ(3, math_util::percentage_to_value(50, 5));
+  EXPECT_EQ(2.5f, (math_util::percentage_to_value<int, float>(50, 5)));
+  EXPECT_EQ(0, math_util::percentage_to_value(0, 5));
+  EXPECT_EQ(1, math_util::percentage_to_value(10, 5));
+  EXPECT_EQ(1, math_util::percentage_to_value(20, 5));
+  EXPECT_EQ(2, math_util::percentage_to_value(30, 5));
+  EXPECT_EQ(2, math_util::percentage_to_value(40, 5));
+  EXPECT_EQ(3, math_util::percentage_to_value(50, 5));
+  EXPECT_EQ(5, math_util::percentage_to_value(100, 5));
+  EXPECT_EQ(5, math_util::percentage_to_value(200, 5));
+  EXPECT_EQ(0, math_util::percentage_to_value(-30, 5));
+}
 
-  "ranged_percentage_to_value"_test = [] {
-    expect(math_util::percentage_to_value(50, 200, 300) == 250);
-    expect(math_util::percentage_to_value(50, 1, 5) == 3);
-  };
+TEST(Math, rangedPercentageToValue) {
+  EXPECT_EQ(250, math_util::percentage_to_value(50, 200, 300));
+  EXPECT_EQ(3, math_util::percentage_to_value(50, 1, 5));
+}
 
-  "round_to_nearest_10"_test = [] {
-    expect(math_util::nearest_10(52) == 50);
-    expect(math_util::nearest_10(9.1) == 10);
-    expect(math_util::nearest_10(95.0) == 100);
-    expect(math_util::nearest_10(94.9) == 90);
-  };
+TEST(Math, roundToNearest10) {
+  EXPECT_EQ(50, math_util::nearest_10(52));
+  EXPECT_EQ(10, math_util::nearest_10(9.1));
+  EXPECT_EQ(100, math_util::nearest_10(95.0));
+  EXPECT_EQ(90, math_util::nearest_10(94.9));
+}
 
-  "round_to_nearest_5"_test = [] {
-    expect(math_util::nearest_5(52) == 50);
-    expect(math_util::nearest_5(9.1) == 10);
-    expect(math_util::nearest_5(95.0) == 95);
-    expect(math_util::nearest_5(94.9) == 95);
-    expect(math_util::nearest_5(1) == 0);
-    expect(math_util::nearest_5(99.99) == 100);
-  };
+TEST(Math, roundToNearest5) {
+  EXPECT_EQ(50, math_util::nearest_5(52));
+  EXPECT_EQ(10, math_util::nearest_5(9.1));
+  EXPECT_EQ(95, math_util::nearest_5(95.0));
+  EXPECT_EQ(95, math_util::nearest_5(94.9));
+  EXPECT_EQ(0, math_util::nearest_5(1));
+  EXPECT_EQ(100, math_util::nearest_5(99.99));
 }

--- a/tests/unit_tests/utils/scope.cpp
+++ b/tests/unit_tests/utils/scope.cpp
@@ -1,21 +1,19 @@
 #include "common/test.hpp"
 #include "utils/scope.hpp"
 
-int main() {
-  using namespace polybar;
+using namespace polybar;
 
-  "on_exit"_test = [] {
-    auto flag = false;
+TEST(Scope, onExit) {
+  auto flag = false;
+  {
+    EXPECT_FALSE(flag);
+    auto handler = scope_util::make_exit_handler<>([&] { flag = true; });
+    EXPECT_FALSE(flag);
     {
-      expect(!flag);
       auto handler = scope_util::make_exit_handler<>([&] { flag = true; });
-      expect(!flag);
-      {
-        auto handler = scope_util::make_exit_handler<>([&] { flag = true; });
-      }
-      expect(flag);
-      flag = false;
     }
-    expect(flag);
-  };
+    EXPECT_TRUE(flag);
+    flag = false;
+  }
+  EXPECT_TRUE(flag);
 }


### PR DESCRIPTION
This converts all legacy tests to use googletest. Except for the string test which was already converted in #1237. I will open a new PR, once this and #1237 are merged to remove the legacy testing functions in `test.hpp`

Closes #127 because we know have a proper testing setup and testing all the things is something we will never achieve so otherwise this issue would just stay open forever