### PR TITLE
[WIP] cli: If cli option is substring of another both are recognized

### DIFF
--- a/tests/unit_tests/components/command_line.cpp
+++ b/tests/unit_tests/components/command_line.cpp
@@ -18,6 +18,7 @@ class CommandLine : public ::testing::Test {
       // clang-format off
       return command_line::options {
         command_line::option{"-f", "--flag", "Flag description"},
+        command_line::option{"-g", "--flag-second", "Flag description"},
         command_line::option{"-o", "--option", "Option description", "OPTION", {"foo", "bar", "baz"}},
       };
       // clang-format on
@@ -26,6 +27,12 @@ class CommandLine : public ::testing::Test {
     command_line::parser::make_type cli;
 };
 
+TEST_F(CommandLine, longSubstring) {
+  EXPECT_NO_THROW(cli->process_input(string_util::split("--flag-second", ' ')));
+
+  EXPECT_TRUE(cli->has("flag-second"));
+  EXPECT_FALSE(cli->has("flag"));
+}
 
 TEST_F(CommandLine, hasShort) {
   cli->process_input(string_util::split("-f", ' '));


### PR DESCRIPTION
Welp, I found a bug in the command line argument parser

If a long option is a substring of another, if the other one is used, the substring is also recognized.

It appears to only happen, if the longer option is defined after the substring one