### PR TITLE
Reorganize build instructions on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Some of the services included so far:
 If you are using **Arch Linux**, you can install the AUR package [polybar-git](https://aur.archlinux.org/packages/polybar-git/) to get the latest version, or
 [polybar](https://aur.archlinux.org/packages/polybar/) for the latest stable release. If you create a package for any other distribution, please consider contributing the template.
 
-If you are using **Void Linux**, you can install [polybar](https://github.com/voidlinux/void-packages/blob/master/srcpkgs/polybar/template) using `xbps-install -S polybar`.
+If you are using **Void Linux**, you can install [polybar](https://github.com/void-linux/void-packages/blob/master/srcpkgs/polybar/template) using `xbps-install -S polybar`.
 
 If you are using **NixOS**, polybar is available in both the stable and unstable channels and can be installed with the command `nix-env -iA nixos.polybar`.
 
@@ -81,9 +81,9 @@ If you are using **Source Mage GNU/Linux**, polybar spell is available in test g
 
 If you are using **openSUSE**, polybar is available from [OBS](https://build.opensuse.org/package/show/home:sysek/polybar) repository. For now package is only for Tumbleweed.
 
-If you are using **FreeBSD**, polybar can be installed using `pkg install polybar`. Make sure you are using the `latest` package branch.
+If you are using **FreeBSD**, [polybar](https://svnweb.freebsd.org/ports/head/x11/polybar/) can be installed using `pkg install polybar`. Make sure you are using the `latest` package branch.
 
-If you are using **Gentoo**, both release and git-master versions are available in the main repository.
+If you are using **Gentoo**, both release and git-master versions are available in the [main](https://packages.gentoo.org/packages/x11-misc/polybar) repository.
 
 ### Dependencies
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ If you are using **Gentoo**, both release and git-master versions are available 
 
 ### Dependencies
 
-A compiler with C++14 support ([clang-3.4+](http://llvm.org/releases/download.html), [gcc-5.1+](https://gcc.gnu.org/releases.html)).
+A compiler with C++14 support ([clang-3.4+](http://llvm.org/releases/download.html), [gcc-5.1+](https://gcc.gnu.org/releases.html)), [cmake 3.1+](https://cmake.org/download/), [git](https://git-scm.com/downloads)
 - cairo
 - libxcb
 - python2

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ There's also a helper script available in the root folder:
   $ ./build.sh
   ~~~
 
+For more info, have a look at the [Compiling wiki page](https://github.com/jaagr/polybar/wiki/Compiling).
 
 ### Configuration
 

--- a/README.md
+++ b/README.md
@@ -66,8 +66,13 @@ Some of the services included so far:
     <img src="https://repology.org/badge/vertical-allrepos/polybar.svg" alt="Packaging status" align="right">
 </a>
 
+Polybar was already packaged for the distros listed below.
+If you can't find your distro here, you will have to [build from source](#building-from-source).
+
+If you create a package for any other distribution, please consider contributing the template.
+
 If you are using **Arch Linux**, you can install the AUR package [polybar-git](https://aur.archlinux.org/packages/polybar-git/) to get the latest version, or
-[polybar](https://aur.archlinux.org/packages/polybar/) for the latest stable release. If you create a package for any other distribution, please consider contributing the template.
+[polybar](https://aur.archlinux.org/packages/polybar/) for the latest stable release.
 
 If you are using **Void Linux**, you can install [polybar](https://github.com/void-linux/void-packages/blob/master/srcpkgs/polybar/template) using `xbps-install -S polybar`.
 

--- a/README.md
+++ b/README.md
@@ -141,9 +141,10 @@ For more info, have a look at the [Compiling wiki page](https://github.com/jaagr
 Details on how to setup and configure the bar and each module have been moved to [the wiki](https://github.com/jaagr/polybar/wiki/Configuration).
 
 #### Install the example configuration
-  ~~~ sh
-  $ make userconfig
-  ~~~
+Run the following inside the build directory:
+~~~ sh
+$ make userconfig
+~~~
 
 #### Launch the example bar
   ~~~ sh


### PR DESCRIPTION
I have already cleaned up the [Compiling](https://github.com/jaagr/polybar/wiki/Compiling) wiki page and have now also done some cleanup in the README to clarify things a bit.