### PR TITLE
Fix battery refresh when swapping power /(issue #839 and #1181)

### DIFF
--- a/include/modules/battery.hpp
+++ b/include/modules/battery.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
 #include "common.hpp"
-#include "modules/meta/inotify_module.hpp"
+#include "meta/base.hpp"
 
 POLYBAR_NS
 
 namespace modules {
-  class battery_module : public inotify_module<battery_module> {
+  class battery_module : public module<battery_module> {
    public:
     enum class state {
       NONE = 0,
@@ -88,12 +88,15 @@ namespace modules {
     animation_t m_animation_discharging;
     progressbar_t m_bar_capacity;
     ramp_t m_ramp_capacity;
+    map<string, int> m_watchlist;
 
     string m_fstate;
     string m_fcapnow;
     string m_fcapfull;
     string m_frate;
     string m_fvoltage;
+    string path_battery;
+    string path_adapter;
 
     state m_state{state::DISCHARGING};
     int m_percentage{0};
@@ -104,7 +107,11 @@ namespace modules {
     chrono::duration<double> m_interval{};
     chrono::system_clock::time_point m_lastpoll;
     thread m_subthread;
+
+    void runner();
+    void poll_events();
+    void recreate_watches();
   };
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/include/modules/meta/inotify_module.hpp
+++ b/include/modules/meta/inotify_module.hpp
@@ -8,16 +8,7 @@ POLYBAR_NS
 namespace modules {
   template <class Impl>
   class inotify_module : public module<Impl> {
-   public:
-    using module<Impl>::module;
-
-    void start() {
-      this->m_mainthread = thread(&inotify_module::runner, this);
-    }
-
-   protected:
-    void runner() {
-      this->m_log.trace("%s: Thread id = %i", this->name(), concurrency_util::thread_id(this_thread::get_id()));
+   public: using module<Impl>::module; void start() { this->m_mainthread = thread(&inotify_module::runner, this); } protected: void runner() { this->m_log.trace("%s: Thread id = %i", this->name(), concurrency_util::thread_id(this_thread::get_id()));
       try {
         // Warm up module output before entering the loop
         std::unique_lock<std::mutex> guard(this->m_updatelock);


### PR DESCRIPTION
Here is a fix for correcting the behavior of polybar when suspending.

The paths for monitoring the battery state can change in a running system,
for example after a suspend.

Therefore now the battery module now tries to find the correct battery paths
after a failing inotify watch.

For the implementation i merged the logic of the inotify_module into the battery modules
for an easy fix.