### PR TITLE
fix(i3): Send workspace cmd unconditionally on click

### DIFF
--- a/src/modules/i3.cpp
+++ b/src/modules/i3.cpp
@@ -223,10 +223,8 @@ namespace modules {
 
       if (cmd.compare(0, strlen(EVENT_CLICK), EVENT_CLICK) == 0) {
         cmd.erase(0, strlen(EVENT_CLICK));
-        if (i3_util::focused_workspace(conn)->name != cmd) {
-          m_log.info("%s: Sending workspace focus command to ipc handler", name());
-          conn.send_command("workspace " + cmd);
-        }
+        m_log.info("%s: Sending workspace focus command to ipc handler", name());
+        conn.send_command("workspace " + cmd);
         return true;
       }
 


### PR DESCRIPTION
This makes polybar play nice with the i3wm feature `workspace_auto_back_and_forth`, and it is harmless when that option isn't set.