### PR TITLE
Release 3.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Find a more complete list on the [dedicated wiki page](https://github.com/jaagr/
 Please [report any problems](https://github.com/jaagr/polybar/issues/new) you run into when building the project.
 
   ~~~ sh
-  $ git clone --branch 3.1.0 --recursive https://github.com/jaagr/polybar
+  $ git clone --branch 3.2 --recursive https://github.com/jaagr/polybar
   $ mkdir polybar/build
   $ cd polybar/build
   $ cmake ..

--- a/contrib/polybar-git.aur/PKGBUILD
+++ b/contrib/polybar-git.aur/PKGBUILD
@@ -2,8 +2,8 @@
 # Contributor: Michael Carlberg <c@rlberg.se>
 _pkgname=polybar
 pkgname="${_pkgname}-git"
-pkgver=3.1.0
-pkgrel=3
+pkgver=3.2.0
+pkgrel=1
 pkgdesc="A fast and easy-to-use status bar"
 arch=("i686" "x86_64")
 url="https://github.com/jaagr/polybar"

--- a/contrib/polybar.aur/PKGBUILD
+++ b/contrib/polybar.aur/PKGBUILD
@@ -1,16 +1,18 @@
 # Maintainer: Michael Carlberg <c@rlberg.se>
 # Contributor: Michael Carlberg <c@rlberg.se>
 pkgname=polybar
-pkgver=3.1.0
-pkgrel=4
+pkgver=3.2.0
+pkgrel=1
 pkgdesc="A fast and easy-to-use status bar"
 arch=("i686" "x86_64")
 url="https://github.com/jaagr/polybar"
 license=("MIT")
 depends=("cairo" "xcb-util-image" "xcb-util-wm" "xcb-util-xrm" "xcb-util-cursor")
 optdepends=("alsa-lib: alsa module support"
+            "pulseaudio: pulseaudio module support"
             "libmpdclient: mpd module support"
-            "wireless_tools: network module support"
+            "libnl: network module support"
+            "wireless_tools: network module support (legacy)"
             "jsoncpp: i3 module support"
             "i3-wm: i3 module support"
             "ttf-unifont: Font used in example config"
@@ -23,9 +25,7 @@ source=("${pkgname}::git+${url}.git#tag=${pkgver}")
 md5sums=("SKIP")
 
 prepare() {
-  git -C "${pkgname}" cherry-pick -n 8173a6473e50a3bb0ff15e56644fa45268be84a4
   git -C "${pkgname}" submodule update --init --recursive
-  git -C "${pkgname}/lib/xpp" checkout 00165e1a6d5dd61bc153e1352b21ec07fc81245d
   mkdir -p "${pkgname}/build"
 }
 

--- a/include/version.hpp
+++ b/include/version.hpp
@@ -1,4 +1,4 @@
 #pragma once
 
-#define GIT_TAG "3.1.0"
-#define GIT_TAG_NAMESPACE v3_1_0
+#define GIT_TAG "3.2.0"
+#define GIT_TAG_NAMESPACE v3_2_0


### PR DESCRIPTION
I think the 3.2.0 release is badly needed right now, for one because xcb-proto 1.13 is getting more and more common, making the 'eventstruct' issue (#973) catch on (see #1335, #1330, #1294, #1252, #1233, #1090, #1114) and also 3.1.0 cannot be compiled with gcc 8 without manually updating the i3ipcpp submodule.

The [3.2.0 Milestone](https://github.com/jaagr/polybar/milestone/2) contained quite a few unfinished issues, I have moved almost all of them into the [3.3.0 Milestone](https://github.com/jaagr/polybar/milestone/4) because this release now has some urgency to it.
The only issue I kept was #1194, because there is already a fix for it (#1198), it just needs to be reviewed and merged.

With this release, I'd like to also propose some guidelines on how we do releases. The base idea is that each minor (and major) release (like 3.0.0, 3.1.0, 3.2.0, etc) gets its own branch. The name of the branch is the version number with the patch number dropped (e.g. 3.2, 4.0, etc) so that we don't get any conflicts with the git tags for the versions (that's why in the README I used `--branch 3.2`). Development continues on `master`, no actual work is done directly in the release branches. If we need to release a patch version (e.g. 3.2.1), for example because of a critical bug, we cherry-pick the commit that fixes the bug onto the current release branch (*Note:* The 3.2.1 tag is only present in the release branch, the `master` branch now only contains the tags for minor and major releases). So we basically backport the fixes, this way we don't have to create minor releases for every bug, just because we implemented a feature in the meantime. It also prevents the behaviour we have now, where we have to patch up the PKGBUILDs and write extra instructions just to get the current version to compile.

I'd like to get your feedback on these release guidelines, if you approve, I will write a page on the wiki with a release protocol.

**Things to do before merging:**
- [x] Write changelog and add it to the github release tag
- [x] Check if all new features are documented on the wiki

**Things to do after this is merged:**
- [ ] Remove `(unreleased)` note from new features in the wiki
- [ ] Create the `3.2` branch with this PR as its base commit.
- [ ] Publish drafted release with target on the `3.2` branch
- [ ] Ensure AUR packages build properly and have proper version tags
- [ ] Push updated PKGBUILDs (and .SRCINFO)

@NBonaparte could you please review #1198 so that we can fix that bug for this release.