### PR TITLE
refactor: Remove unnecessary quote trim operations

### DIFF
--- a/src/components/builder.cpp
+++ b/src/components/builder.cpp
@@ -90,10 +90,6 @@ void builder::node(string str, bool add_space) {
   string::size_type n, m;
   string s(move(str));
 
-  if ((n = s.size()) > 2 && s[0] == '"' && s[n - 1] == '"') {
-    s = s.substr(1, n - 2);
-  }
-
   while (true) {
     if (s.empty()) {
       break;

--- a/src/drawtypes/label.cpp
+++ b/src/drawtypes/label.cpp
@@ -151,12 +151,6 @@ namespace drawtypes {
       text = conf.get(section, name, move(def));
     }
 
-    size_t len{text.size()};
-
-    if (len > 2 && text[0] == '"' && text[len - 1] == '"') {
-      text = text.substr(1, len - 2);
-    }
-
     const auto get_left_right = [&](string key) {
       auto value = conf.get(section, key, 0U);
       auto left = conf.get(section, key + "-left", value);

--- a/src/modules/date.cpp
+++ b/src/modules/date.cpp
@@ -13,10 +13,10 @@ namespace modules {
       datetime_stream.imbue(std::locale(m_bar.locale.c_str()));
     }
 
-    m_dateformat = string_util::trim(m_conf.get(name(), "date", ""s), '"');
-    m_dateformat_alt = string_util::trim(m_conf.get(name(), "date-alt", ""s), '"');
-    m_timeformat = string_util::trim(m_conf.get(name(), "time", ""s), '"');
-    m_timeformat_alt = string_util::trim(m_conf.get(name(), "time-alt", ""s), '"');
+    m_dateformat = m_conf.get(name(), "date", ""s);
+    m_dateformat_alt = m_conf.get(name(), "date-alt", ""s);
+    m_timeformat = m_conf.get(name(), "time", ""s);
+    m_timeformat_alt = m_conf.get(name(), "time-alt", ""s);
 
     if (m_dateformat.empty() && m_timeformat.empty()) {
       throw module_error("No date or time format specified");


### PR DESCRIPTION
Trimming the quotes in labels and the date module are not needed at all,
because surrounding quotes are removed when loading the values from the
config.

Removing the quotes in the builder also doesn't seem to serve any
purpose at all.