### PR TITLE
Added timezones

### DIFF
--- a/include/modules/date.hpp
+++ b/include/modules/date.hpp
@@ -32,10 +32,14 @@ namespace modules {
     string m_dateformat;
     string m_dateformat_alt;
     string m_timeformat;
+    string m_time_timezone; 
+    string m_time_timezone_2; 
     string m_timeformat_alt;
 
     string m_date;
+    string m_date_2;
     string m_time;
+    string m_time_2;
 
     // Single stringstream to be used to gather the results of std::put_time
     std::stringstream datetime_stream;

--- a/include/modules/date.hpp
+++ b/include/modules/date.hpp
@@ -33,13 +33,10 @@ namespace modules {
     string m_dateformat_alt;
     string m_timeformat;
     string m_time_timezone; 
-    string m_time_timezone_2; 
     string m_timeformat_alt;
 
     string m_date;
-    string m_date_2;
     string m_time;
-    string m_time_2;
 
     // Single stringstream to be used to gather the results of std::put_time
     std::stringstream datetime_stream;

--- a/src/modules/date.cpp
+++ b/src/modules/date.cpp
@@ -17,7 +17,6 @@ namespace modules {
     m_dateformat_alt = string_util::trim(m_conf.get(name(), "date-alt", ""s), '"');
     m_timeformat = string_util::trim(m_conf.get(name(), "time", ""s), '"');
     m_time_timezone = string_util::trim(m_conf.get(name(), "time-TZ", ""s), '"');
-    m_time_timezone_2 = string_util::trim(m_conf.get(name(), "time-2-TZ", ""s), '"');
     m_timeformat_alt = string_util::trim(m_conf.get(name(), "time-alt", ""s), '"');
 
     if (m_dateformat.empty() && m_timeformat.empty()) {
@@ -47,7 +46,6 @@ namespace modules {
     const char* timezone_format_original = getenv("TZ");
 
     string timezone_format = m_time_timezone;
-    string timezone_format_2 = m_time_timezone_2;
     if (timezone_format != ""){ 
       setenv("TZ", timezone_format.c_str(), 1);
     }
@@ -64,38 +62,17 @@ namespace modules {
     datetime_stream << std::put_time(localtime(&time), time_format.c_str());
     auto time_string = datetime_stream.str();
 
-    //Secondary time zone
-    string date_string_2, time_string_2;
-    if(timezone_format_2 != ""){
-      setenv("TZ", timezone_format_2.c_str(), 1);
-      auto date_format = m_toggled ? m_dateformat_alt : m_dateformat;
-      // Clear stream contents
-      datetime_stream.str("");
-      datetime_stream << std::put_time(localtime(&time), date_format.c_str());
-      date_string_2 = datetime_stream.str();
-
-      auto time_format = m_toggled ? m_timeformat_alt : m_timeformat;
-      // Clear stream contents
-      datetime_stream.str("");
-      datetime_stream << std::put_time(localtime(&time), time_format.c_str());
-      time_string_2 = datetime_stream.str();
-    }
-
     if (m_date == date_string && m_time == time_string) {
       return false;
     }
 
     m_date = date_string;
-    m_date_2 = date_string_2;
     m_time = time_string;
-    m_time_2 = time_string_2;
 
     if (m_label) {
       m_label->reset_tokens();
       m_label->replace_token("%date%", m_date);
-      m_label->replace_token("%date-2%", m_date_2);
       m_label->replace_token("%time%", m_time);
-      m_label->replace_token("%time-2%", m_time_2);
     }
 
     //Reset TZ so other modules work fine

--- a/src/modules/date.cpp
+++ b/src/modules/date.cpp
@@ -16,6 +16,8 @@ namespace modules {
     m_dateformat = string_util::trim(m_conf.get(name(), "date", ""s), '"');
     m_dateformat_alt = string_util::trim(m_conf.get(name(), "date-alt", ""s), '"');
     m_timeformat = string_util::trim(m_conf.get(name(), "time", ""s), '"');
+    m_time_timezone = string_util::trim(m_conf.get(name(), "time-TZ", ""s), '"');
+    m_time_timezone_2 = string_util::trim(m_conf.get(name(), "time-2-TZ", ""s), '"');
     m_timeformat_alt = string_util::trim(m_conf.get(name(), "time-alt", ""s), '"');
 
     if (m_dateformat.empty() && m_timeformat.empty()) {
@@ -41,6 +43,15 @@ namespace modules {
   bool date_module::update() {
     auto time = std::time(nullptr);
 
+    //Timezone format business
+    const char* timezone_format_original = getenv("TZ");
+
+    string timezone_format = m_time_timezone;
+    string timezone_format_2 = m_time_timezone_2;
+    if (timezone_format != ""){ 
+      setenv("TZ", timezone_format.c_str(), 1);
+    }
+
     auto date_format = m_toggled ? m_dateformat_alt : m_dateformat;
     // Clear stream contents
     datetime_stream.str("");
@@ -53,17 +64,44 @@ namespace modules {
     datetime_stream << std::put_time(localtime(&time), time_format.c_str());
     auto time_string = datetime_stream.str();
 
+    //Secondary time zone
+    string date_string_2, time_string_2;
+    if(timezone_format_2 != ""){
+      setenv("TZ", timezone_format_2.c_str(), 1);
+      auto date_format = m_toggled ? m_dateformat_alt : m_dateformat;
+      // Clear stream contents
+      datetime_stream.str("");
+      datetime_stream << std::put_time(localtime(&time), date_format.c_str());
+      date_string_2 = datetime_stream.str();
+
+      auto time_format = m_toggled ? m_timeformat_alt : m_timeformat;
+      // Clear stream contents
+      datetime_stream.str("");
+      datetime_stream << std::put_time(localtime(&time), time_format.c_str());
+      time_string_2 = datetime_stream.str();
+    }
+
     if (m_date == date_string && m_time == time_string) {
       return false;
     }
 
     m_date = date_string;
+    m_date_2 = date_string_2;
     m_time = time_string;
+    m_time_2 = time_string_2;
 
     if (m_label) {
       m_label->reset_tokens();
       m_label->replace_token("%date%", m_date);
+      m_label->replace_token("%date-2%", m_date_2);
       m_label->replace_token("%time%", m_time);
+      m_label->replace_token("%time-2%", m_time_2);
+    }
+
+    //Reset TZ so other modules work fine
+    if (timezone_format_original){
+      //Prevents empty char*
+      setenv("TZ", timezone_format_original,1);
     }
 
     return true;


### PR DESCRIPTION
Added the ability to display two clocks on the date module and the ability to set the timezone on those two clocks. This solves #596 and also addresses the problem of #788 in that the fix does not use any external modules, instead relying on setting the TZ environment variable. 

Currently the options for customization are such that users can set the setting **time-TZ** and **time-2-TZ** on their polybar config file to set the timezones of two separate clocks. The options date-2 and time-2 can be added to the label to give the ability to display a dual clock. date-2 is set using the time-2-TZ variable and is not independent of time-2. 

Here's an example using my polybar config file:
```
type = internal/date
interval = 1

date =  %a, %b %d
date-alt =  %Y-%m-%d 

time = "%H:%M"
time-TZ = "Asia/Singapore"
time-2-TZ = "America/Detroit"
time-alt = "%H:%M:%S"

label = %date%   %time% | %date-2%   %time-2%
```
![My config](https://user-images.githubusercontent.com/7616132/43384560-fec32e9e-9410-11e8-8def-d224d1974a20.png)

Minor bugs: currently, setting the option time-2-TZ but _not_ time-TZ results in both clocks having the secondary time zone. I don't know how to fix this bug at the moment.

Improvements: I intend to work on a version of this module that allows users to have different timezone when they click on the module, instead of just changing the format.

Fixes #596 
Fixes #1293