### PR TITLE
fix(net): Allow all characters for the SSID

### DIFF
--- a/src/adapters/net_nl.cpp
+++ b/src/adapters/net_nl.cpp
@@ -182,9 +182,7 @@ namespace net {
         auto essid_begin = ies + hdr_len;
         auto essid_end = essid_begin + ies[1];
 
-        // Only use printable characters of the current locale
-        std::copy_if(essid_begin, essid_end, std::back_inserter(m_essid),
-            [](char c) { return isprint(static_cast<unsigned char>(c)); });
+        std::copy(essid_begin, essid_end, std::back_inserter(m_essid));
       }
     }
   }


### PR DESCRIPTION
Don't filter out any character that is not part of the current C locale, since it might drop some wanted characters.

Fixes #1367