### PR TITLE
removes big unused if

### DIFF
--- a/src/components/config.cpp
+++ b/src/components/config.cpp
@@ -238,17 +238,7 @@ template <>
 bool config::convert(string&& value) const {
   string lower{string_util::lower(forward<string>(value))};
 
-  if (lower == "true") {
-    return true;
-  } else if (lower == "yes") {
-    return true;
-  } else if (lower == "on") {
-    return true;
-  } else if (lower == "1") {
-    return true;
-  } else {
-    return false;
-  }
+  return (lower == "true" || lower == "yes" || lower == "on" || lower == "1");
 }
 
 template <>

--- a/src/drawtypes/ramp.cpp
+++ b/src/drawtypes/ramp.cpp
@@ -34,7 +34,11 @@ namespace drawtypes {
     vector<icon_t> vec;
     vector<string> icons;
 
-    icons = required ? conf.get_list<string>(section, name) : conf.get_list<string>(section, name, {});
+    if (required) {
+      icons = conf.get_list<string>(section, name);
+    } else {
+      icons = conf.get_list<string>(section, name, {});
+    }
 
     for (size_t i = 0; i < icons.size(); i++) {
       auto icon = load_optional_icon(conf, section, name + "-" + to_string(i), icons[i]);

--- a/src/ipc.cpp
+++ b/src/ipc.cpp
@@ -38,15 +38,7 @@ void remove_pipe(const string& handle) {
 }
 
 bool validate_type(const string& type) {
-  if (type == "action") {
-    return true;
-  } else if (type == "cmd") {
-    return true;
-  } else if (type == "hook") {
-    return true;
-  } else {
-    return false;
-  }
+  return (type == "action" || type == "cmd" || type == "hook");
 }
 
 int main(int argc, char** argv) {

--- a/src/x11/cursor.cpp
+++ b/src/x11/cursor.cpp
@@ -4,9 +4,7 @@ POLYBAR_NS
 
 namespace cursor_util {
   bool valid(string name) {
-    if (cursors.find(name) != cursors.end())
-      return true;
-    return false;
+    return (cursors.find(name) != cursors.end());
   }
 
   bool set_cursor(xcb_connection_t *c, xcb_screen_t *screen, xcb_window_t w, string name) {


### PR DESCRIPTION
another option would be
 ```cpp
if (type == "action" || type == "cmd" || type == "hook") {
    return true;
}
return false;
```