### PR TITLE
github: Custom issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,39 @@
+---
+name: Bug or Issue Report
+about: Create a report to help us improve
+
+---
+
+## Describe the issue
+*A clear and concise description of what the bug is.*
+
+**Expected behavior:**
+
+*A clear and concise description of what you expected to happen.*
+
+**Actual behavior:**
+
+*What actually happens*
+
+## To Reproduce
+*A minimal but complete config with which the problem occurs:*
+```dosini
+
+```
+*List any other steps needed to reproduce the issue besides starting polybar with the config you posted above.*
+
+## Polybar Log
+*Post everything polybar outputs to the terminal when you run it and the issue occurs below*
+```
+
+```
+
+## Screenshots
+*If applicable, add screenshots to help explain your problem.*
+
+## Environment:
+* WM:
+* Output of `polybar -vvv`:
+
+## Additional context
+*Add any other context that you think is necessary about the problem here.*

--- a/.github/ISSUE_TEMPLATE/build.md
+++ b/.github/ISSUE_TEMPLATE/build.md
@@ -1,0 +1,31 @@
+---
+name: Build Issues
+about: Report issues while building polybar
+
+---
+
+## Build Process
+*Describe how you build polybar, list the exact commands you are using:*
+
+
+
+**If you build polybar directly from this repository:**
+
+* Output of `git describe --tags`:
+
+**If you use some other way (like the AUR):**
+
+*List exactly where you are building from and which version you are building.*
+
+
+## Build Log
+*Post everything that is output to the terminal while building polybar below. This HAS to include the output of the `cmake` and `make` commands, if you used them.*
+```
+
+```
+
+## Environment:
+* Distro (with Version):
+
+## Additional context
+*Add any other context that you think is necessary about the problem here.*

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+## Is your feature request related to a problem? Please describe.
+*A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]*
+
+## Why does polybar need this feature?
+*Describe why this feature would be useful to a large percentage of users (You need to convince us).*
+
+## Describe the solution you'd like
+*A clear and concise description of how your solution would work. This includes possible config options that should be added.*
+
+## Describe alternatives you've considered
+*A clear and concise description of any alternative solutions or features you've considered, if any.*
+
+## Additional context
+*Add any other context or screenshots about the feature request here.*

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Here are a few screenshots showing you what it can look like:
 
 If you need help, check out the [Support](SUPPORT.md) page.
 
-Please report any issues or bugs you may find by [creating an issue ticket](https://github.com/jaagr/polybar/issues/new) here on GitHub.
+Please report any issues or bugs you may find by [creating an issue ticket](https://github.com/jaagr/polybar/issues/new/choose) here on GitHub.
 Make sure you include steps on how to reproduce it. There's also an irc channel available at freenode, cleverly named `#polybar`.
 
 
@@ -118,7 +118,7 @@ Find a more complete list on the [dedicated wiki page](https://github.com/jaagr/
 
 ### Building from source
 
-Please [report any problems](https://github.com/jaagr/polybar/issues/new) you run into when building the project.
+Please [report any problems](https://github.com/jaagr/polybar/issues/new/choose) you run into when building the project.
 
   ~~~ sh
   $ git clone --branch 3.2 --recursive https://github.com/jaagr/polybar


### PR DESCRIPTION
With this we *finally* have some issue templates so that we can directly get all the information we need from the user without having to go back and forth.

The feature request template now also puts the burden on the user to make a case why a certain feature should be added. This should help us to more clearly be able to distinguish between features that would fit the project and ones that wouldn't.

Once this is merged, users should see the following dialog when trying to open a new issue, which I think is pretty neat:
![2018-08-17-205436_805x311_scrot](https://user-images.githubusercontent.com/2452038/44283971-4308a400-a260-11e8-8b47-0d15b7a5525b.png)
