### PR TITLE
fix(compiling): `map` variable without namespace.

### DIFF
--- a/include/x11/cursor.hpp
+++ b/include/x11/cursor.hpp
@@ -15,7 +15,7 @@
 POLYBAR_NS
 
 namespace cursor_util {
-  static const map<string, vector<string>> cursors = {
+  static const std::map<string, vector<string>> cursors = {
     {"pointer", {"pointing_hand", "pointer", "hand", "hand1", "hand2", "e29285e634086352946a0e7090d73106", "9d800788f1b08800ae810202380a0822"}},
     {"default", {"left_ptr", "arrow", "dnd-none", "op_left_arrow"}},
     {"ns-resize", {"size_ver", "sb_v_double_arrow", "v_double_arrow", "n-resize", "s-resize", "col-resize", "top_side", "bottom_side", "base_arrow_up", "base_arrow_down", "based_arrow_down", "based_arrow_up", "00008160000006810000408080010102"}}


### PR DESCRIPTION
It seems that if you don't have `xcb-xkb` installed, you get a compilation error because `cursor.hpp` uses `map` without `std::` in front of it. When you install `xcb-xkb` back, it includes `x11/extensions/xkb.hpp` which has `using std::map`.

I can reproduce this error on branch 3.2, too.