### PR TITLE
fix(gtest): prefer target_link_libraries

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,7 +2,6 @@
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fprofile-arcs -ftest-coverage -Wno-missing-field-initializers")
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fprofile-arcs -ftest-coverage")
 
-link_libraries(${libs})
 include_directories(${dirs})
 include_directories(${CMAKE_CURRENT_LIST_DIR})
 
@@ -59,7 +58,7 @@ function(unit_test file tests)
   add_executable(${name} unit_tests/${file}.cpp ${sources})
 
   # Link against gmock (this automatically links against gtest)
-  target_link_libraries(${name} gmock_main)
+  target_link_libraries(${name} gmock_main ${libs})
 
   add_test(NAME ${name} COMMAND ${name})
 


### PR DESCRIPTION
From commit 880896c6f4814f4c7798355a652dc6167be2b75f in googletest cmake
test configuration fails with errors like

CMake Error: install(EXPORT "gtestConfigInternal" ...) includes target
  "gtest" which requires target "i3ipc++" that is not in the export set.

The issue was that link_libraries also affected the googletest internal
targets that came after it making the whole thing fail.

This could also have been solved by moving link_libraries after the
configuration of googletest but according to the cmake documentation [1]
target_link_libraries should be prefered over link_libraries anyways.

[1]: https://cmake.org/cmake/help/latest/command/link_libraries.html

Fixes #1393