### PR TITLE
Fixed tray repain issue #1143

### DIFF
--- a/src/x11/tray_manager.cpp
+++ b/src/x11/tray_manager.cpp
@@ -382,7 +382,7 @@ void tray_manager::reconfigure_clients() {
  * Reconfigure root pixmap
  */
 void tray_manager::reconfigure_bg(bool realloc) {
-  if (!m_opts.transparent || m_clients.empty() || !m_mapped) {
+  if (m_clients.empty() || !m_mapped) {
     return;
   } else if (!m_rootpixmap) {
     realloc = true;


### PR DESCRIPTION
The error occured due to the tray's background not being repainted with `tray-transparent = false`