### PR TITLE
fix(cpu): Replace %percentage-cores% normally

### DIFF
--- a/src/modules/cpu.cpp
+++ b/src/modules/cpu.cpp
@@ -34,16 +34,6 @@ namespace modules {
       m_rampload_core = load_ramp(m_conf, name(), TAG_RAMP_LOAD_PER_CORE);
     }
     if (m_formatter->has(TAG_LABEL)) {
-      // Update the label parameter and replace the %percentag-cores% token with the individual core tokens
-      string key{&TAG_LABEL[1], strlen(TAG_LABEL) - 2};
-      auto label = m_conf.get<string>(name(), key, "%percentage%%");
-      vector<string> cores;
-      for (size_t i = 1; i <= m_cputimes.size(); i++) {
-        cores.emplace_back("%percentage-core" + to_string(i) + "%%");
-      }
-      label = string_util::replace_all(label, "%percentage-cores%", string_util::join(cores, " "));
-      const_cast<config&>(m_conf).set(name(), key, move(label));
-
       m_label = load_optional_label(m_conf, name(), TAG_LABEL, "%percentage%%");
     }
   }
@@ -77,6 +67,7 @@ namespace modules {
     if (m_label) {
       m_label->reset_tokens();
       m_label->replace_token("%percentage%", to_string(static_cast<int>(m_total + 0.5)));
+      m_label->replace_token("%percentage-cores%", string_util::join(percentage_cores, "% ") + "%");
 
       for (size_t i = 0; i < percentage_cores.size(); i++) {
         m_label->replace_token("%percentage-core" + to_string(i + 1) + "%", percentage_cores[i]);


### PR DESCRIPTION
Resolves #1282 

This pretty much restores the way things were done pre 3292cea where the token splitting shenanigans were introduced.