### PR TITLE
fix(font): Check FcNameParse return value

### DIFF
--- a/include/cairo/font.hpp
+++ b/include/cairo/font.hpp
@@ -257,6 +257,12 @@ namespace cairo {
     });
 
     auto pattern = FcNameParse((FcChar8*)fontname.c_str());
+
+    if(!pattern) {
+      logger::make().err("Could not parse font \"%s\"", fontname);
+      throw application_error("Could not parse font \"" + fontname + "\"");
+    }
+
     FcDefaultSubstitute(pattern);
     FcConfigSubstitute(nullptr, pattern, FcMatchPattern);
 


### PR DESCRIPTION
If FcNameParse returns NULL FcDefaultSubstitute segfaults

We log and throw an error here because the signal emitter swallows all
exceptions so if that exception was thrown, the bar would stop rendering
without any indication as to why.

Fixes #1435