### PR TITLE
replace caddr_t with char*

### DIFF
--- a/src/adapters/net.cpp
+++ b/src/adapters/net.cpp
@@ -194,7 +194,7 @@ namespace net {
      */
     strncpy(request.ifr_name, m_interface.c_str(), IFNAMSIZ - 1);
 
-    request.ifr_data = reinterpret_cast<caddr_t>(&driver);
+    request.ifr_data = reinterpret_cast<char*>(&driver);
 
     if (ioctl(*m_socketfd, SIOCETHTOOL, &request) == -1) {
       return;
@@ -258,7 +258,7 @@ namespace net {
     memset(&request, 0, sizeof(request));
     strncpy(request.ifr_name, m_interface.c_str(), IFNAMSIZ - 1);
     data.cmd = ETHTOOL_GSET;
-    request.ifr_data = reinterpret_cast<caddr_t>(&data);
+    request.ifr_data = reinterpret_cast<char*>(&data);
 
     if (ioctl(*m_socketfd, SIOCETHTOOL, &request) == -1) {
       return false;
@@ -283,7 +283,7 @@ namespace net {
     memset(&request, 0, sizeof(request));
     strncpy(request.ifr_name, m_interface.c_str(), IFNAMSIZ - 1);
     data.cmd = ETHTOOL_GLINK;
-    request.ifr_data = reinterpret_cast<caddr_t>(&data);
+    request.ifr_data = reinterpret_cast<char*>(&data);
 
     if (ioctl(*m_socketfd, SIOCETHTOOL, &request) == -1) {
       return false;


### PR DESCRIPTION
overriding my [old pr](https://github.com/jaagr/polybar/pull/1452) to source from a proper issue branch for [issue 1447](https://github.com/jaagr/polybar/issues/1447)

Replaces old 'caddr_t' type with generic 'char*'

EDIT: Fixes #1447