### PR TITLE
fix(cmd): Escape all colons in action tag command

### DIFF
--- a/src/components/builder.cpp
+++ b/src/components/builder.cpp
@@ -499,11 +499,7 @@ void builder::underline_close() {
  */
 void builder::cmd(mousebtn index, string action, bool condition) {
   if (condition && !action.empty()) {
-    size_t p{0};
-    while ((p = action.find(':', p)) != string::npos && action[p - 1] != '\\') {
-      action.insert(p, 1, '\\');
-      p++;
-    }
+    action = string_util::replace_all(action, ":", "\\:");
     tag_open(syntaxtag::A, to_string(static_cast<int>(index)) + ":" + action + ":");
   }
 }

--- a/src/components/parser.cpp
+++ b/src/components/parser.cpp
@@ -232,6 +232,11 @@ mousebtn parser::parse_action_btn(const string& data) {
 
 /**
  * Process action command string
+ *
+ * data is the action cmd surrounded by unescaped colons followed by an
+ * arbitrary string
+ *
+ * Returns everything inside the unescaped colons as is
  */
 string parser::parse_action_cmd(string&& data) {
   if (data[0] != ':') {

--- a/src/components/renderer.cpp
+++ b/src/components/renderer.cpp
@@ -798,7 +798,7 @@ bool renderer::on(const signals::parser::action_begin& evt) {
   action.button = a.button == mousebtn::NONE ? mousebtn::LEFT : a.button;
   action.align = m_align;
   action.start_x = m_blocks.at(m_align).x;
-  action.command = string_util::replace_all(a.command, "\\:", ":");
+  action.command = a.command;
   action.active = true;
   m_actions.emplace_back(action);
   return true;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -100,5 +100,14 @@ unit_test(components/builder unit_tests
   SOURCES
   ${files})
 
+unit_test(components/parser unit_tests
+  SOURCES
+  components/parser.cpp
+  utils/factory.cpp
+  utils/string.cpp
+  events/signal_emitter.cpp
+  events/signal_receiver.cpp
+  )
+
 # Compile all unit tests with 'make all_unit_tests'
 add_custom_target("all_unit_tests" DEPENDS ${unit_tests})

--- a/tests/unit_tests/components/parser.cpp
+++ b/tests/unit_tests/components/parser.cpp
@@ -1,0 +1,37 @@
+#include "common/test.hpp"
+#include "events/signal_emitter.hpp"
+#include "components/parser.hpp"
+
+using namespace polybar;
+
+class TestableParser : public parser {
+  using parser::parser;
+  public: using parser::parse_action_cmd;
+};
+
+class Parser : public ::testing::Test {
+  protected:
+    TestableParser m_parser{signal_emitter::make()};
+};
+/**
+ * The first element of the pair is the expected return text, the second element
+ * is the input to parse_action_cmd
+ */
+class ParseActionCmd :
+  public Parser,
+  public ::testing::WithParamInterface<pair<string, string>> {};
+
+vector<pair<string, string>> parse_action_cmd_list = {
+  {"abc", ":abc:\\abc"},
+  {"abc\\:", ":abc\\::\\abc"},
+  {"\\:\\:\\:", ":\\:\\:\\::\\abc"},
+};
+
+INSTANTIATE_TEST_CASE_P(Inst, ParseActionCmd,
+    ::testing::ValuesIn(parse_action_cmd_list),);
+
+TEST_P(ParseActionCmd, correctness) {
+  auto input = GetParam().second;
+  auto result = m_parser.parse_action_cmd(std::move(input));
+  EXPECT_EQ(GetParam().first, result);
+}


### PR DESCRIPTION
The builder::cmd function creates a new action block with a command.
However it fails to escape all colons and only escapes the first colon

~For now I have refactored the code a bit and added failing unit tests to
show the bug. I will implement the proper behaviour in the next few
days (hopefully).
This changes the semantics a bit: We now also escape the escape character so that we get the exact same command back that we put in.~

Fixes #984 