### PR TITLE
fix: Move return value of parse_layout_symbol

### DIFF
--- a/src/x11/extensions/xkb.cpp
+++ b/src/x11/extensions/xkb.cpp
@@ -208,7 +208,7 @@ namespace xkb_util {
     if (string_util::contains(LAYOUT_SYMBOL_BLACKLIST, ";" + name + ";")) {
       return "";
     }
-    return name;
+    return move(name);
   }
 }
 


### PR DESCRIPTION
Fixes #1469

I wasn't sure if I should use std::forward here but decided against it since the function is not templated. rvalue references still give me headaches ^^