### PR TITLE
Add ramp-padding capabilities to module/cpu

### DIFF
--- a/contrib/polybar.aur/PKGBUILD
+++ b/contrib/polybar.aur/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Michael Carlberg <c@rlberg.se>
 # Contributor: Michael Carlberg <c@rlberg.se>
 pkgname=polybar
-pkgver=3.2.0
+pkgver=3.2.1
 pkgrel=1
 pkgdesc="A fast and easy-to-use status bar"
 arch=("i686" "x86_64")

--- a/include/modules/cpu.hpp
+++ b/include/modules/cpu.hpp
@@ -37,6 +37,7 @@ namespace modules {
     ramp_t m_rampload;
     ramp_t m_rampload_core;
     label_t m_label;
+    int m_ramp_padding;
 
     vector<cpu_time_t> m_cputimes;
     vector<cpu_time_t> m_cputimes_prev;

--- a/include/version.hpp
+++ b/include/version.hpp
@@ -1,4 +1,4 @@
 #pragma once
 
-#define GIT_TAG "3.2.0"
-#define GIT_TAG_NAMESPACE v3_2_0
+#define GIT_TAG "3.2.1"
+#define GIT_TAG_NAMESPACE v3_2_1

--- a/src/components/controller.cpp
+++ b/src/components/controller.cpp
@@ -348,7 +348,12 @@ void controller::read_events() {
  */
 void controller::process_eventqueue() {
   m_log.info("Eventqueue worker (thread-id=%lu)", this_thread::get_id());
-  m_sig.emit(signals::eventqueue::start{});
+  if (!m_writeback) {
+    m_sig.emit(signals::eventqueue::start{});
+  } else {
+    // bypass the start eventqueue signal
+    m_sig.emit(signals::ui::ready{});
+  }
 
   while (!g_terminate) {
     event evt{};

--- a/src/drawtypes/ramp.cpp
+++ b/src/drawtypes/ramp.cpp
@@ -14,7 +14,7 @@ namespace drawtypes {
   }
 
   icon_t ramp::get_by_percentage(float percentage) {
-    size_t index = percentage * (m_icons.size() - 1) / 100.0f + 0.5f;
+    size_t index = percentage * m_icons.size() / 100.0f;
     return m_icons[math_util::cap<size_t>(index, 0, m_icons.size() - 1)];
   }
 

--- a/src/modules/cpu.cpp
+++ b/src/modules/cpu.cpp
@@ -18,6 +18,8 @@ namespace modules {
   cpu_module::cpu_module(const bar_settings& bar, string name_) : timer_module<cpu_module>(bar, move(name_)) {
     m_interval = m_conf.get<decltype(m_interval)>(name(), "interval", 1s);
 
+    m_ramp_padding = m_conf.get<decltype(m_ramp_padding)>(name(), "ramp-padding");
+
     m_formatter->add(DEFAULT_FORMAT, TAG_LABEL, {TAG_LABEL, TAG_BAR_LOAD, TAG_RAMP_LOAD, TAG_RAMP_LOAD_PER_CORE});
 
     // warmup cpu times
@@ -97,7 +99,7 @@ namespace modules {
       auto i = 0;
       for (auto&& load : m_load) {
         if (i++ > 0) {
-          builder->space(1);
+          builder->space(m_ramp_padding);
         }
         builder->node(m_rampload_core->get_by_percentage(load));
       }

--- a/src/modules/cpu.cpp
+++ b/src/modules/cpu.cpp
@@ -18,7 +18,7 @@ namespace modules {
   cpu_module::cpu_module(const bar_settings& bar, string name_) : timer_module<cpu_module>(bar, move(name_)) {
     m_interval = m_conf.get<decltype(m_interval)>(name(), "interval", 1s);
 
-    m_ramp_padding = m_conf.get<decltype(m_ramp_padding)>(name(), "ramp-padding");
+    m_ramp_padding = m_conf.get<decltype(m_ramp_padding)>(name(), "ramp-coreload-spacing", 1);
 
     m_formatter->add(DEFAULT_FORMAT, TAG_LABEL, {TAG_LABEL, TAG_BAR_LOAD, TAG_RAMP_LOAD, TAG_RAMP_LOAD_PER_CORE});
 

--- a/src/modules/i3.cpp
+++ b/src/modules/i3.cpp
@@ -223,10 +223,8 @@ namespace modules {
 
       if (cmd.compare(0, strlen(EVENT_CLICK), EVENT_CLICK) == 0) {
         cmd.erase(0, strlen(EVENT_CLICK));
-        if (i3_util::focused_workspace(conn)->name != cmd) {
-          m_log.info("%s: Sending workspace focus command to ipc handler", name());
-          conn.send_command("workspace " + cmd);
-        }
+        m_log.info("%s: Sending workspace focus command to ipc handler", name());
+        conn.send_command("workspace " + cmd);
         return true;
       }
 


### PR DESCRIPTION
Fixes #1389 
Allows "ramp-padding" in polybar config file to adjust spacing between core loads.