### PR TITLE
feat(cpu): Add ramp-coreload-spacing (#1472)

### DIFF
--- a/include/modules/cpu.hpp
+++ b/include/modules/cpu.hpp
@@ -37,6 +37,7 @@ namespace modules {
     ramp_t m_rampload;
     ramp_t m_rampload_core;
     label_t m_label;
+    int m_ramp_padding;
 
     vector<cpu_time_t> m_cputimes;
     vector<cpu_time_t> m_cputimes_prev;

--- a/src/modules/cpu.cpp
+++ b/src/modules/cpu.cpp
@@ -18,7 +18,7 @@ namespace modules {
   cpu_module::cpu_module(const bar_settings& bar, string name_) : timer_module<cpu_module>(bar, move(name_)) {
     m_interval = m_conf.get<decltype(m_interval)>(name(), "interval", 1s);
 
-    m_ramp_padding = m_conf.get<decltype(m_ramp_padding)>(name(), "ramp-padding");
+    m_ramp_padding = m_conf.get<decltype(m_ramp_padding)>(name(), "ramp-coreload-spacing", 1);
 
     m_formatter->add(DEFAULT_FORMAT, TAG_LABEL, {TAG_LABEL, TAG_BAR_LOAD, TAG_RAMP_LOAD, TAG_RAMP_LOAD_PER_CORE});
 

--- a/src/modules/cpu.cpp
+++ b/src/modules/cpu.cpp
@@ -18,6 +18,8 @@ namespace modules {
   cpu_module::cpu_module(const bar_settings& bar, string name_) : timer_module<cpu_module>(bar, move(name_)) {
     m_interval = m_conf.get<decltype(m_interval)>(name(), "interval", 1s);
 
+    m_ramp_padding = m_conf.get<decltype(m_ramp_padding)>(name(), "ramp-padding");
+
     m_formatter->add(DEFAULT_FORMAT, TAG_LABEL, {TAG_LABEL, TAG_BAR_LOAD, TAG_RAMP_LOAD, TAG_RAMP_LOAD_PER_CORE});
 
     // warmup cpu times
@@ -88,7 +90,7 @@ namespace modules {
       auto i = 0;
       for (auto&& load : m_load) {
         if (i++ > 0) {
-          builder->space(1);
+          builder->space(m_ramp_padding);
         }
         builder->node(m_rampload_core->get_by_percentage(load));
       }


### PR DESCRIPTION
Resolves #1389

This just is just the commits in #1472 cherry-picked because the original PR was against `3.2` and contained the 3.2.1 release commit