### PR TITLE
Accept a locally existing build-directory

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -178,11 +178,11 @@ main() {
       msg "Removing existing build dir (-f)"
       rm -rf ./build >/dev/null || msg_err "Failed to remove existing build dir"
     else
-      msg_err "A build dir already exists (pass -f to replace)"
+      msg "A build dir already exists (pass -f to replace)"
     fi
   }
 
-  mkdir ./build || msg_err "Failed to create build dir"
+  mkdir -p ./build || msg_err "Failed to create build dir"
   cd ./build || msg_err "Failed to enter build dir"
 
   set_build_opts


### PR DESCRIPTION
While working on polybar, I found it super-convenient that the `build.sh` does everything needed to build the project. Back then, I change the script a little to have my preferences automatically as default. With the recent revamp of the build-script, all options became scriptable, so my shell-history was sufficient. One little thing remained, though. The build-directory wanted to be destroyed every time. Since I was in favor of faster feedback, I changed the script a little. Upon further reflection, I think this could even be the default.

This PR accepts a locally existing build-directory. A message is emitted and the '--force' option to remove it is still honored. However, if people want to reuse the build-directory to reduce recompile-times, this gives them the rope they ask for.

What to you think?