### PR TITLE
feat(pulseaudio): add headphones detection

### DIFF
--- a/include/adapters/pulseaudio.hpp
+++ b/include/adapters/pulseaudio.hpp
@@ -43,6 +43,7 @@ class pulseaudio {
     void set_mute(bool mode);
     void toggle_mute();
     bool is_muted();
+    bool is_headphone();
 
   private:
     void update_volume(pa_operation *o);
@@ -63,6 +64,7 @@ class pulseaudio {
     bool muted{false};
     // default sink name
     static constexpr auto DEFAULT_SINK{"@DEFAULT_SINK@"};
+    string active_port_name;
 
     pa_context* m_context{nullptr};
     pa_threaded_mainloop* m_mainloop{nullptr};

--- a/include/modules/pulseaudio.hpp
+++ b/include/modules/pulseaudio.hpp
@@ -31,9 +31,12 @@ namespace modules {
     static constexpr auto FORMAT_MUTED = "format-muted";
 
     static constexpr auto TAG_RAMP_VOLUME = "<ramp-volume>";
+    static constexpr auto TAG_RAMP_HEADPHONES = "<ramp-headphones>";
     static constexpr auto TAG_BAR_VOLUME = "<bar-volume>";
     static constexpr auto TAG_LABEL_VOLUME = "<label-volume>";
     static constexpr auto TAG_LABEL_MUTED = "<label-muted>";
+    static constexpr auto TAG_LABEL_HEADPHONES_VOLUME = "<label-headphones-volume>";
+    static constexpr auto TAG_LABEL_HEADPHONES_MUTED = "<label-headphones-muted>";
 
     static constexpr auto EVENT_PREFIX = "pa_vol";
     static constexpr auto EVENT_VOLUME_UP = "pa_volup";
@@ -42,13 +45,17 @@ namespace modules {
 
     progressbar_t m_bar_volume;
     ramp_t m_ramp_volume;
+    ramp_t m_ramp_headphones;
     label_t m_label_volume;
     label_t m_label_muted;
+    label_t m_label_headphones_volume;
+    label_t m_label_headphones_muted;
 
     pulseaudio_t m_pulseaudio;
 
     int m_interval{5};
     atomic<bool> m_muted{false};
+    atomic<bool> m_headphones{false};
     atomic<int> m_volume{0};
   };
 }

--- a/src/adapters/pulseaudio.cpp
+++ b/src/adapters/pulseaudio.cpp
@@ -216,6 +216,21 @@ bool pulseaudio::is_muted() {
 }
 
 /**
+ * True if sink's active_port is a headphone
+ */
+bool pulseaudio::is_headphone() {
+  // see pulseaudio source - src/pulse/proplist.h:211 PA_PROP_DEVICE_FORM_FACTOR
+  vector<string> form_factors{"headphone", "headset", "hands-free"};
+  if (!active_port_name.empty()) {
+    for (size_t i = 0; i < form_factors.size(); i++) {
+      if (active_port_name.find(form_factors[i]) != string::npos)
+        return true;
+    }
+  }
+  return false;
+}
+
+/**
  * Update local volume cache
  */
 void pulseaudio::update_volume(pa_operation *o) {
@@ -231,6 +246,9 @@ void pulseaudio::get_sink_volume_callback(pa_context *, const pa_sink_info *info
   if (info) {
     This->cv = info->volume;
     This->muted = info->mute;
+    if (info->active_port) {
+      This->active_port_name = info->active_port->name;
+    }
   }
   pa_threaded_mainloop_signal(This->m_mainloop, 0);
 }


### PR DESCRIPTION
Properly detect if current sink is a headphone and change labels or ramps accordingly.
That's the only feature that pulseaudio module was lacking, and i finally found some free time to implement it. I tested this commit and i think everything works as expected, but please review these changes.
Label/ramp replacement is similar to alsa module. 

```dosini
; Available tags:
;   <label-volume> (default)
;   <ramp-volume>
;   <bar-volume>
format-volume = <ramp-volume> <label-volume>

; Available tags:
;   <label-muted> (default)
;   <ramp-volume>
;   <bar-volume>
;format-muted = <label-muted>

; Available tokens:
;   %percentage% (default)
;label-volume = %percentage%%

; If defined will replace <label-volume> when headphones are plugged in
; Available tokens:
;   %percentage%
;   null (default)
;label-headphones-volume =   %percentage%%

; Available tokens:
;   %percentage% (default)
label-muted = 🔇 muted
label-muted-foreground = #66

; If defined will replace <label-muted> when headphones are plugged in
; Available tokens:
;   %percentage%
;   null (default)
;label-headphones-muted = 🔇

; Only applies if <ramp-volume> is used
ramp-volume-0 = 🔈
ramp-volume-1 = 🔉
ramp-volume-2 = 🔊

; If defined, it will replace <ramp-volume> when headphones are plugged in
; If undefined, <ramp-volume> will be used for both
; Only applies if <ramp-volume> is used
ramp-headphones-0 = 
ramp-headphones-1 = 
```