### PR TITLE
Shift over question and help issues over to irc, reddit, and stackexchange

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
-name: Bug or Issue Report
-about: Create a report to help us improve
+name: Bug Report
+about: Create a report for something that misbehaves
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -33,6 +33,7 @@ about: Create a report to help us improve
 
 ## Environment:
 * WM:
+* Distro:
 * Output of `polybar -vvv`:
 
 ## Additional context

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Make sure you include steps on how to reproduce it.
   * [Building from source](#building-from-source)
   * [Configuration](#configuration)
   * [Running](#running)
+* [Community](#community)
 * [Contributors](#contributors)
 * [License](#license)
 
@@ -158,10 +159,15 @@ $ make userconfig
   $ polybar example
   ~~~
 
-
 ### Running
 
 [See the wiki for details on how to run polybar](https://github.com/jaagr/polybar/wiki).
+
+## Community
+Want to get in touch?
+
+* We have our own subreddit at [r/polybar](https://www.reddit.com/r/polybar).
+* Chat with us in the `#polybar` IRC channel on the `chat.freenode.net` server.
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -19,15 +19,16 @@ Here are a few screenshots showing you what it can look like:
 You can find polybar configs for these example images (and other configs) [here](https://github.com/jaagr/dots/tree/master/.local/etc/themer/themes).
 
 
-If you need help, check out the [Support](SUPPORT.md) page.
+**If you need help**, check out the [Support](SUPPORT.md) page.
 
-Please report any issues or bugs you may find by [creating an issue ticket](https://github.com/jaagr/polybar/issues/new/choose) here on GitHub.
-Make sure you include steps on how to reproduce it. There's also an irc channel available at freenode, cleverly named `#polybar`.
+Please report any bugs you find by [creating an issue ticket](https://github.com/jaagr/polybar/issues/new/choose) here on GitHub.
+Make sure you include steps on how to reproduce it.
 
 
 ## Table of Contents
 
 * [Introduction](#introduction)
+* [Getting Help](#getting-help)
 * [Getting started](#getting-started)
   * [Dependencies](#dependencies)
   * [Building from source](#building-from-source)
@@ -63,6 +64,9 @@ Some of the services included so far:
 
 [See the wiki for more details](https://github.com/jaagr/polybar/wiki).
 
+## Getting Help
+
+If you find yourself stuck, have a look at our [Support](SUPPORT.md) page for resources where you can find help.
 
 ## Getting started
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -5,7 +5,7 @@ If you need help or troubleshooting tips or just have a question:
 
 * Read the [Known Issues page](https://github.com/jaagr/polybar/wiki/Known-Issues), maybe others had the same issue before.
 * Read the [Wiki page](https://github.com/jaagr/polybar/wiki) for the thing you have problems with.
-* Ask in our reddit community at [/r/polybar](https://www.reddit.com/r/polybar)
+* Ask in our reddit community at [r/polybar](https://www.reddit.com/r/polybar)
 * Join the official IRC channel `#polybar` on the `chat.freenode.net` network. Make sure to let your IRC client be connected long enough to get an answer, if you disconnect after 15 minutes, you will likely not get any response.
 * Ask on [Unix & Linux StackExchange](https://unix.stackexchange.com/). Though not all questions may be suited over there, make sure you're [on topic](https://unix.stackexchange.com/help/on-topic).
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,8 +1,12 @@
-Polybar Support
-===============
+Getting Help
+============
 
-Reading [Polybar Wiki](https://github.com/jaagr/polybar/wiki) should help you with most of the problems you encounter when using polybar. It has a page for each module, describing what it does and what configuration options it provides.
+If you need help or troubleshooting tips or just have a question:
 
-If you can't find the information you are looking for on the wiki, look through the existing [issues](https://github.com/jaagr/polybar/issues?q=is%3Aissue), to see if anyone had the same problem before.
+* Read the [Known Issues page](https://github.com/jaagr/polybar/wiki/Known-Issues), maybe others had the same issue before.
+* Read the [Wiki page](https://github.com/jaagr/polybar/wiki) for the thing you have problems with.
+* Ask in our reddit community at [/r/polybar](https://www.reddit.com/r/polybar)
+* Join the official IRC channel `#polybar` on the `chat.freenode.net` network. Make sure to let your IRC client be connected long enough to get an answer, if you disconnect after 15 minutes, you will likely not get any response.
+* Ask on [Unix & Linux StackExchange](https://unix.stackexchange.com/). Though not all questions may be suited over there, make sure you're [on topic](https://unix.stackexchange.com/help/on-topic).
 
-If you are still not able to resolve your problem, go ahead and open a new issue and also document what you have done up to that point to solve the problem.
+Please **do not** use the github issue tracker to ask for help or if you have a question, it is meant for bug reports and feature requests. Issues will be closed and you will be referred to the above resources.


### PR DESCRIPTION
With this I want to try to get fewer questions and tech support issues in our issue tracker. This will help us focus more on the actual issues.

The idea is get the community to reddit and irc for discussions and questions and have this repo be more focused on code.

To monitor new questions on those platforms, I suggest all of us core devs monitor the following places for new questions:

* [1]: For any posts mentioning polybar on reddit
* [2]: The rss feed of the r/polybar subreddit
* [3]: For all stackexchange questions mentioning polybar. Note this list cannot be sorted by date and new results may show up only after a few days.
* [4]: For all unix.stackexchange.com questions mentioning polybar. This list is sorted by date.

I have also created a github saved reply for closing issues that only ask a question or for help:

```
The issue tracker is meant for bug reports and feature requests. Please don't ask support questions here, read our [Support page](https://github.com/jaagr/polybar/blob/master/SUPPORT.md) for a list of resources where you can ask questions. We are more than happy to help you there.
```

What do you think of this approach? I really want to get our issue tracker cleaned up and I think this will help and hopefully also help us better build our community.

@NBonaparte, @skystrife if you would be willing to also be present on the IRC channel (at least from time to time), please post your irc nick and jaagr can give you permanent op on the channel.

@jaagr If we do this, could you also give all of us full permissions for the polybar subreddit so that we can effectively moderate it. My username is `patrick96MC`.

[1]: https://www.reddit.com/search?q=polybar&sort=new&type=link
[2]: https://www.reddit.com/r/polybar/.rss
[3]: https://stackexchange.com/search?q=polybar
[4]: https://unix.stackexchange.com/search?tab=newest&q=polybar

Ref: #802
