### PR TITLE
fix(build): remove side-effects of iwlib.h

### DIFF
--- a/include/adapters/net.hpp
+++ b/include/adapters/net.hpp
@@ -6,16 +6,6 @@
 #include <arpa/inet.h>
 #include <ifaddrs.h>
 
-#ifdef inline
-#undef inline
-#endif
-
-#include "common.hpp"
-#include "settings.hpp"
-#include "errors.hpp"
-#include "components/logger.hpp"
-#include "utils/math.hpp"
-
 #if WITH_LIBNL
 #include <net/if.h>
 
@@ -23,7 +13,22 @@ struct nl_msg;
 struct nlattr;
 #else
 #include <iwlib.h>
+
+/*
+ * wirless_tools 29 (and possibly earlier) redefines 'inline' in iwlib.h
+ * With clang this leads to a conflict in the POLYBAR_NS macro
+ * wirless_tools 30 doesn't have that issue anymore
+ */
+#ifdef inline
+#undef inline
 #endif
+#endif
+
+#include "common.hpp"
+#include "settings.hpp"
+#include "errors.hpp"
+#include "components/logger.hpp"
+#include "utils/math.hpp"
 
 POLYBAR_NS
 

--- a/src/adapters/net.cpp
+++ b/src/adapters/net.cpp
@@ -12,10 +12,6 @@
 #include <sys/ioctl.h>
 #include <sys/socket.h>
 
-#ifdef inline
-#undef inline
-#endif
-
 #include "common.hpp"
 #include "settings.hpp"
 #include "utils/command.hpp"


### PR DESCRIPTION
wireless_tools 29 redefines inline in iwlib.h as:
    #define inline inline __attribute__((always_inline))

which conflicts with POLYBAR_NS, which is defined as:

    #define POLYBAR_NS    \
      namespace polybar { \
        inline namespace APP_VERSION_NAMESPACE {

In version 30.pre9 this #define is moved into a source file and thus
cannot conflict.

The error only occurs when building with clang, so it seems gcc and
clang handle this differently

Fixes #1492