### PR TITLE
fix(net): make sure WITH_LIBNL is defined before checking

### DIFF
--- a/include/adapters/net.hpp
+++ b/include/adapters/net.hpp
@@ -6,6 +6,12 @@
 #include <arpa/inet.h>
 #include <ifaddrs.h>
 
+#include "common.hpp"
+#include "settings.hpp"
+#include "errors.hpp"
+#include "components/logger.hpp"
+#include "utils/math.hpp"
+
 #if WITH_LIBNL
 #include <net/if.h>
 
@@ -23,12 +29,6 @@ struct nlattr;
 #undef inline
 #endif
 #endif
-
-#include "common.hpp"
-#include "settings.hpp"
-#include "errors.hpp"
-#include "components/logger.hpp"
-#include "utils/math.hpp"
 
 POLYBAR_NS
 


### PR DESCRIPTION
Missed this in #1493...

`#include "settings.hpp"` should be declared before the `#if WITH_LIBNL` macro, otherwise it isn't defined.
I moved the other includes with it to make it neater.