### PR TITLE
coverage: Allow small drops in coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,15 @@
+coverage:
+  status:
+    project:
+      default:
+        # Coverage can drop by 0.1% without failing the status
+        threshold: 0.1
+    patch:
+      default:
+        # Patches don't need test coverage
+        # TODO remove once we have proper testing infrastructure and documentation
+        target: 0
+
 ignore:
   - "tests/*"
   - "lib/*"


### PR DESCRIPTION
Most PRs change code where no tests have been written so far and where
adding tests is difficult. Codecov fails all those PRs.

These values should be adjusted once we have better integrated testing
into our workflow and have written better testing infrastructure for
modules and very tightly coupled components