### PR TITLE
fix: strict monitor name matching

### DIFF
--- a/include/components/types.hpp
+++ b/include/components/types.hpp
@@ -123,6 +123,7 @@ struct bar_settings {
 
   xcb_window_t window{XCB_NONE};
   monitor_t monitor{};
+  bool monitor_exact{true};
   edge origin{edge::TOP};
   struct size size {
     1U, 1U

--- a/include/components/types.hpp
+++ b/include/components/types.hpp
@@ -123,6 +123,7 @@ struct bar_settings {
 
   xcb_window_t window{XCB_NONE};
   monitor_t monitor{};
+  bool monitor_strict{false};
   bool monitor_exact{true};
   edge origin{edge::TOP};
   struct size size {

--- a/include/x11/extensions/randr.hpp
+++ b/include/x11/extensions/randr.hpp
@@ -37,7 +37,7 @@ struct randr_output {
   xcb_randr_output_t output;
   backlight_values backlight;
 
-  bool match(const string& o, bool strict = false) const;
+  bool match(const string& o, bool exact = true) const;
   bool match(const position& p) const;
 };
 
@@ -50,6 +50,7 @@ namespace randr_util {
 
   monitor_t make_monitor(xcb_randr_output_t randr, string name, unsigned short int w, unsigned short int h, short int x, short int y);
   vector<monitor_t> get_monitors(connection& conn, xcb_window_t root, bool connected_only = false, bool realloc = false);
+  monitor_t match_monitor(vector<monitor_t> monitors, const string& name, bool exact_match);
 
   void get_backlight_range(connection& conn, const monitor_t& mon, backlight_values& dst);
   void get_backlight_value(connection& conn, const monitor_t& mon, backlight_values& dst);

--- a/src/components/bar.cpp
+++ b/src/components/bar.cpp
@@ -72,15 +72,15 @@ bar::bar(connection& conn, signal_emitter& emitter, const config& config, const 
   // Get available RandR outputs
   auto monitor_name = m_conf.get(bs, "monitor", ""s);
   auto monitor_name_fallback = m_conf.get(bs, "monitor-fallback", ""s);
-  auto monitor_strictmode = m_conf.get(bs, "monitor-strict", false);
+  m_opts.monitor_strict = m_conf.get(bs, "monitor-strict", m_opts.monitor_strict);
   m_opts.monitor_exact = m_conf.get(bs, "monitor-exact", m_opts.monitor_exact);
-  auto monitors = randr_util::get_monitors(m_connection, m_connection.screen()->root, monitor_strictmode);
+  auto monitors = randr_util::get_monitors(m_connection, m_connection.screen()->root, m_opts.monitor_strict);
 
   if (monitors.empty()) {
     throw application_error("No monitors found");
   }
 
-  if (monitor_name.empty() && !monitor_strictmode) {
+  if (monitor_name.empty() && !m_opts.monitor_strict) {
     auto connected_monitors = randr_util::get_monitors(m_connection, m_connection.screen()->root, true);
     if (!connected_monitors.empty()) {
       monitor_name = connected_monitors[0]->name;

--- a/src/modules/xbacklight.cpp
+++ b/src/modules/xbacklight.cpp
@@ -19,9 +19,8 @@ namespace modules {
   xbacklight_module::xbacklight_module(const bar_settings& bar, string name_)
       : static_module<xbacklight_module>(bar, move(name_)), m_connection(connection::make()) {
     auto output = m_conf.get(name(), "output", m_bar.monitor->name);
-    auto strict = m_conf.get(name(), "monitor-strict", false);
 
-    auto monitors = randr_util::get_monitors(m_connection, m_connection.root(), strict);
+    auto monitors = randr_util::get_monitors(m_connection, m_connection.root(), bar.monitor_strict);
 
     m_output = randr_util::match_monitor(monitors, output, bar.monitor_exact);
 

--- a/src/modules/xbacklight.cpp
+++ b/src/modules/xbacklight.cpp
@@ -21,13 +21,9 @@ namespace modules {
     auto output = m_conf.get(name(), "output", m_bar.monitor->name);
     auto strict = m_conf.get(name(), "monitor-strict", false);
 
-    // Grab a list of all outputs and try to find the one defined in the config
-    for (auto&& mon : randr_util::get_monitors(m_connection, m_connection.root(), strict)) {
-      if (mon->match(output, strict)) {
-        m_output.swap(mon);
-        break;
-      }
-    }
+    auto monitors = randr_util::get_monitors(m_connection, m_connection.root(), strict);
+
+    m_output = randr_util::match_monitor(monitors, output, bar.monitor_exact);
 
     // If we didn't get a match we stop the module
     if (!m_output) {
@@ -44,7 +40,7 @@ namespace modules {
       randr_util::get_backlight_value(m_connection, m_output, backlight);
     } catch (const exception& err) {
       m_log.err("%s: Could not get data (err: %s)", name(), err.what());
-      throw module_error("Not supported for \"" + output + "\"");
+      throw module_error("Not supported for \"" + m_output->name + "\"");
     }
 
     // Create window that will proxy all RandR notify events


### PR DESCRIPTION
~randr_output::match would match regardless of if there is a dash in the
monitor name.
This was done because jaagr's monitors didn't have a dash in them
depending on the graphics driver used. This behavior was introduced in
[1].~

~This behavior creates issues in situations where a user has a monitor
with a dash in its name and one without e.g. HDMI-2 and HDMI2 (see
 #1532). In both cases polybar would be loaded on monitor HDMI2.~

~Monitor name matching should always be strict~

~[1]: 4d7f6c14e65332793e313866ba05539d3776cf65~

EDIT: This now introduces `monitor-exact` in the bar section which defaults to true and if set to false does fuzzy monitor matching (ignores dashes in monitor names).

It also removes `monitor-strict` from the xbacklight module and uses `monitor-strict` from the bar section. This config option was never documented, so it shouldn't break too many setups (which can all easily be fixed).

Fixes #1532