### PR TITLE
feat(bspwm): Support marked flag for focused nodes

### DIFF
--- a/include/modules/bspwm.hpp
+++ b/include/modules/bspwm.hpp
@@ -27,7 +27,8 @@ namespace modules {
       STATE_PSEUDOTILED,
       NODE_LOCKED,
       NODE_STICKY,
-      NODE_PRIVATE
+      NODE_PRIVATE,
+      NODE_MARKED
     };
 
     struct bspwm_monitor {

--- a/src/modules/bspwm.cpp
+++ b/src/modules/bspwm.cpp
@@ -122,6 +122,7 @@ namespace modules {
       m_modelabels.emplace(mode::NODE_LOCKED, load_optional_label(m_conf, name(), "label-locked"));
       m_modelabels.emplace(mode::NODE_STICKY, load_optional_label(m_conf, name(), "label-sticky"));
       m_modelabels.emplace(mode::NODE_PRIVATE, load_optional_label(m_conf, name(), "label-private"));
+      m_modelabels.emplace(mode::NODE_MARKED, load_optional_label(m_conf, name(), "label-marked"));
     }
 
     m_labelseparator = load_optional_label(m_conf, name(), "label-separator", "");
@@ -318,6 +319,9 @@ namespace modules {
                 break;
               case 'P':
                 mode_flag = mode::NODE_PRIVATE;
+                break;
+              case 'M':
+                mode_flag = mode::NODE_MARKED;
                 break;
               default:
                 m_log.warn("%s: Undefined G => '%s'", name(), value.substr(i, 1));


### PR DESCRIPTION
This adds a new label in the bspwm module `label-marked`

This flag for focused nodes of a focused desktop was introduced earlier this year
and released with bspwm 0.9.4

It adds the `M` flag to `G` type items in bspwm's report format

Resolves #1552

Ref: https://github.com/baskerville/bspwm/commit/d0138af475541732d3f2ae25dff558c07062e24f