### PR TITLE
Added an option to replace xkb indicator names

### DIFF
--- a/include/modules/xkeyboard.hpp
+++ b/include/modules/xkeyboard.hpp
@@ -21,6 +21,19 @@ namespace modules {
       : public static_module<xkeyboard_module>,
         public event_handler<evt::xkb_new_keyboard_notify, evt::xkb_state_notify, evt::xkb_indicator_state_notify>,
         public input_handler {
+   
+   enum class indicator_state {
+     NONE,
+     /**
+      * @brief Indicator is off
+      */
+     OFF,
+     /**
+      * @brief Indicator is on
+      */
+     ON
+   };
+
    public:
     explicit xkeyboard_module(const bar_settings& bar, string name_);
 
@@ -43,10 +56,10 @@ namespace modules {
     static constexpr const char* TAG_LABEL_INDICATOR{"<label-indicator>"};
     static constexpr const char* FORMAT_DEFAULT{"<label-layout> <label-indicator>"};
     static constexpr const char* DEFAULT_LAYOUT_ICON{"layout-icon-default"};
+    static constexpr const char* DEFAULT_INDICATOR_ICON{"indicator-icon-default"};
     
     static constexpr const char* EVENT_SWITCH{"xkeyboard/switch"};
-    
-    
+
     connection& m_connection;
     event_timer m_xkb_newkb_notify{};
     event_timer m_xkb_state_notify{};
@@ -55,10 +68,13 @@ namespace modules {
 
     label_t m_layout;
     label_t m_indicator;
+    map<indicator_state, label_t> m_indicatorstates;
     map<keyboard::indicator::type, label_t> m_indicators;
 
     vector<string> m_blacklist;
     iconset_t m_layout_icons;
+    iconset_t m_indicator_icons_on;
+    iconset_t m_indicator_icons_off;
   };
 }
 

--- a/include/modules/xkeyboard.hpp
+++ b/include/modules/xkeyboard.hpp
@@ -56,6 +56,7 @@ namespace modules {
     map<keyboard::indicator::type, label_t> m_indicators;
 
     vector<string> m_blacklist;
+    iconset_t m_layout_icons;
   };
 }
 

--- a/include/modules/xkeyboard.hpp
+++ b/include/modules/xkeyboard.hpp
@@ -71,6 +71,8 @@ namespace modules {
     map<indicator_state, label_t> m_indicatorstates;
     map<keyboard::indicator::type, label_t> m_indicators;
 
+    string m_capslock_display_name;
+    string m_numlock_display_name;
     vector<string> m_blacklist;
     iconset_t m_layout_icons;
     iconset_t m_indicator_icons_on;

--- a/include/modules/xkeyboard.hpp
+++ b/include/modules/xkeyboard.hpp
@@ -21,19 +21,6 @@ namespace modules {
       : public static_module<xkeyboard_module>,
         public event_handler<evt::xkb_new_keyboard_notify, evt::xkb_state_notify, evt::xkb_indicator_state_notify>,
         public input_handler {
-   
-   enum class indicator_state {
-     NONE,
-     /**
-      * @brief Indicator is off
-      */
-     OFF,
-     /**
-      * @brief Indicator is on
-      */
-     ON
-   };
-
    public:
     explicit xkeyboard_module(const bar_settings& bar, string name_);
 
@@ -67,8 +54,8 @@ namespace modules {
     unique_ptr<keyboard> m_keyboard;
 
     label_t m_layout;
-    label_t m_indicator;
-    map<indicator_state, label_t> m_indicatorstates;
+    label_t m_indicator_state_on;
+    label_t m_indicator_state_off;
     map<keyboard::indicator::type, label_t> m_indicators;
     map<keyboard::indicator::type, label_t> m_indicator_on_labels;
     map<keyboard::indicator::type, label_t> m_indicator_off_labels;

--- a/include/modules/xkeyboard.hpp
+++ b/include/modules/xkeyboard.hpp
@@ -42,9 +42,11 @@ namespace modules {
     static constexpr const char* TAG_LABEL_LAYOUT{"<label-layout>"};
     static constexpr const char* TAG_LABEL_INDICATOR{"<label-indicator>"};
     static constexpr const char* FORMAT_DEFAULT{"<label-layout> <label-indicator>"};
-
+    static constexpr const char* DEFAULT_LAYOUT_ICON{"layout-icon-default"};
+    
     static constexpr const char* EVENT_SWITCH{"xkeyboard/switch"};
-
+    
+    
     connection& m_connection;
     event_timer m_xkb_newkb_notify{};
     event_timer m_xkb_state_notify{};

--- a/include/modules/xkeyboard.hpp
+++ b/include/modules/xkeyboard.hpp
@@ -70,9 +70,9 @@ namespace modules {
     label_t m_indicator;
     map<indicator_state, label_t> m_indicatorstates;
     map<keyboard::indicator::type, label_t> m_indicators;
+    map<keyboard::indicator::type, label_t> m_indicator_on_labels;
+    map<keyboard::indicator::type, label_t> m_indicator_off_labels;
 
-    string m_capslock_display_name;
-    string m_numlock_display_name;
     vector<string> m_blacklist;
     iconset_t m_layout_icons;
     iconset_t m_indicator_icons_on;

--- a/include/x11/extensions/xkb.hpp
+++ b/include/x11/extensions/xkb.hpp
@@ -49,7 +49,7 @@ namespace evt {
 class keyboard {
  public:
   struct indicator {
-    enum class type { NONE = 0U, CAPS_LOCK, NUM_LOCK };
+    enum class type { NONE = 0U, CAPS_LOCK, NUM_LOCK, SCROLL_LOCK };
     xcb_atom_t atom{};
     unsigned char mask{0};
     string name{};

--- a/src/modules/xkeyboard.cpp
+++ b/src/modules/xkeyboard.cpp
@@ -46,7 +46,7 @@ namespace modules {
     
     // load layout icons
     m_layout_icons = factory_util::shared<iconset>();
-    m_layout_icons->add(DEFAULT_LAYOUT_ICON, load_optional_label(m_conf, name(), DEFAULT_LAYOUT_ICON, "s"));
+    m_layout_icons->add(DEFAULT_LAYOUT_ICON, load_optional_label(m_conf, name(), DEFAULT_LAYOUT_ICON, ""s));
 
     for (const auto& it : m_conf.get_list<string>(name(), "layout-icon", {})) {
       auto vec = string_util::split(it, ';');

--- a/src/modules/xkeyboard.cpp
+++ b/src/modules/xkeyboard.cpp
@@ -6,7 +6,6 @@
 #include "x11/connection.hpp"
 
 #include "modules/meta/base.inl"
-#include "cairo/utils.hpp"
 
 POLYBAR_NS
 

--- a/src/modules/xkeyboard.cpp
+++ b/src/modules/xkeyboard.cpp
@@ -73,9 +73,9 @@ namespace modules {
       for (const auto& it : m_conf.get_list<string>(name(), "indicator-icon", {})) {
         auto icon_triple = string_util::split(it, ';');
         if (icon_triple.size() == 3) {
-          auto const indicator_str = string_util::lower(vec[0]);
-          m_indicator_icons_off->add(indicator_str, factory_util::shared<label>(vec[1]));
-          m_indicator_icons_on->add(indicator_str, factory_util::shared<label>(vec[2]));
+          auto const indicator_str = string_util::lower(icon_triple[0]);
+          m_indicator_icons_off->add(indicator_str, factory_util::shared<label>(icon_triple[1]));
+          m_indicator_icons_on->add(indicator_str, factory_util::shared<label>(icon_triple[2]));
         }
       }
     }

--- a/src/modules/xkeyboard.cpp
+++ b/src/modules/xkeyboard.cpp
@@ -6,6 +6,7 @@
 #include "x11/connection.hpp"
 
 #include "modules/meta/base.inl"
+#include "cairo/utils.hpp"
 
 POLYBAR_NS
 
@@ -22,6 +23,8 @@ namespace modules {
     
     // load layout icons
     m_layout_icons = factory_util::shared<iconset>();
+    m_layout_icons->add(DEFAULT_LAYOUT_ICON, factory_util::shared<label>(
+          m_conf.get(name(), DEFAULT_LAYOUT_ICON, ""s)));
 
     for(const auto& it : m_conf.get_list<string>(name(), "layout-icon", {})) {
       auto vec = string_util::split(it, ';');
@@ -59,12 +62,10 @@ namespace modules {
       m_layout->reset_tokens();
       m_layout->replace_token("%name%", m_keyboard->group_name(m_keyboard->current()));
       
-      auto current_layout = m_keyboard->layout_name(m_keyboard->current());
- 
-      if(m_layout_icons->has(current_layout)) {
-        current_layout = m_layout_icons->get(current_layout)->get();
-      } 
+      auto const current_layout = m_keyboard->layout_name(m_keyboard->current());
+      auto icon = m_layout_icons->get(current_layout, DEFAULT_LAYOUT_ICON);
 
+      m_layout->replace_token("%icon%", icon->get());
       m_layout->replace_token("%layout%", current_layout);
       m_layout->replace_token("%number%", to_string(m_keyboard->current()));
     }

--- a/src/modules/xkeyboard.cpp
+++ b/src/modules/xkeyboard.cpp
@@ -32,6 +32,9 @@ namespace modules {
       }
     }
 
+    m_capslock_display_name = m_conf.get<string>(name(), "capslock-displayname", "");
+    m_numlock_display_name = m_conf.get<string>(name(), "numlock-displayname", "");
+
     // Add formats and elements
     m_formatter->add(DEFAULT_FORMAT, FORMAT_DEFAULT, {TAG_LABEL_LAYOUT, TAG_LABEL_INDICATOR});
 
@@ -69,7 +72,7 @@ namespace modules {
         m_indicator_icons_off->add(DEFAULT_INDICATOR_ICON, factory_util::shared<label>(""s));
         m_indicator_icons_on->add(DEFAULT_INDICATOR_ICON, factory_util::shared<label>(""s));
       }
- 
+
       for (const auto& it : m_conf.get_list<string>(name(), "indicator-icon", {})) {
         auto icon_triple = string_util::split(it, ';');
         if (icon_triple.size() == 3) {
@@ -140,7 +143,6 @@ namespace modules {
           indicator->replace_token("%icon%", icon->get());
           m_indicators.emplace(it, move(indicator));
         }
-      }
     }
 
     // Trigger redraw

--- a/src/modules/xkeyboard.cpp
+++ b/src/modules/xkeyboard.cpp
@@ -103,7 +103,6 @@ namespace modules {
         auto key_name = string_util::replace(string_util::lower(indicator_str), " "s, ""s);
         const auto indicator_key_on = "label-indicator-on-"s + key_name;
         const auto indicator_key_off = "label-indicator-off-"s + key_name;
-        std::cout << indicator_key_on << std::endl;
 
         if (m_conf.has(name(), indicator_key_on)) {
           m_indicator_on_labels.emplace(it, load_optional_label(m_conf, name(), indicator_key_on));

--- a/src/x11/extensions/xkb.cpp
+++ b/src/x11/extensions/xkb.cpp
@@ -181,6 +181,8 @@ namespace xkb_util {
         type = keyboard::indicator::type::CAPS_LOCK;
       } else if (string_util::compare(name, "num lock")) {
         type = keyboard::indicator::type::NUM_LOCK;
+      } else if (string_util::compare(name, "scroll lock")) {
+        type = keyboard::indicator::type::SCROLL_LOCK;
       } else {
         continue;
       }


### PR DESCRIPTION
TEAM EDIT: Fixes #1558 
Closes #1048 

**Changelog Notes:**
This deprecates `label-indicator` in favor of `label-indicator-on`