### PR TITLE
Option to disable click to mute in alsa and pulseaudio modules

### DIFF
--- a/include/modules/alsa.hpp
+++ b/include/modules/alsa.hpp
@@ -58,6 +58,7 @@ namespace modules {
     map<control, control_t> m_ctrl;
     int m_headphoneid{0};
     bool m_mapped{false};
+    bool m_click_to_mute{true};
     int m_interval{5};
     atomic<bool> m_muted{false};
     atomic<bool> m_headphones{false};

--- a/include/modules/pulseaudio.hpp
+++ b/include/modules/pulseaudio.hpp
@@ -48,6 +48,7 @@ namespace modules {
     pulseaudio_t m_pulseaudio;
 
     int m_interval{5};
+    bool m_click_to_mute{true};
     atomic<bool> m_muted{false};
     atomic<int> m_volume{0};
   };

--- a/src/modules/alsa.cpp
+++ b/src/modules/alsa.cpp
@@ -22,6 +22,7 @@ namespace modules {
     // Load configuration values
     m_mapped = m_conf.get(name(), "mapped", m_mapped);
     m_interval = m_conf.get(name(), "interval", m_interval);
+    m_click_to_mute = m_conf.get(name(),"click-to-mute", m_click_to_mute);
 
     auto master_mixer_name = m_conf.get(name(), "master-mixer", "Master"s);
     auto speaker_mixer_name = m_conf.get(name(), "speaker-mixer", ""s);
@@ -244,7 +245,7 @@ namespace modules {
             string{m_mixer[mixer::SPEAKER]->get_name()}, string{m_mixer[mixer::SPEAKER]->get_sound_card()}));
       }
 
-      if (cmd.compare(0, strlen(EVENT_TOGGLE_MUTE), EVENT_TOGGLE_MUTE) == 0) {
+      if (cmd.compare(0, strlen(EVENT_TOGGLE_MUTE), EVENT_TOGGLE_MUTE) == 0 && m_click_to_mute) {
         for (auto&& mixer : mixers) {
           mixer->set_mute(m_muted || mixers[0]->is_muted());
         }

--- a/src/modules/pulseaudio.cpp
+++ b/src/modules/pulseaudio.cpp
@@ -17,6 +17,7 @@ namespace modules {
   pulseaudio_module::pulseaudio_module(const bar_settings& bar, string name_) : event_module<pulseaudio_module>(bar, move(name_)) {
     // Load configuration values
     m_interval = m_conf.get(name(), "interval", m_interval);
+    m_click_to_mute = m_conf.get(name(),"click-to-mute", m_click_to_mute);
 
     auto sink_name = m_conf.get(name(), "sink", ""s);
     bool m_max_volume = m_conf.get(name(), "use-ui-max", true);
@@ -136,7 +137,7 @@ namespace modules {
 
     try {
       if (m_pulseaudio && !m_pulseaudio->get_name().empty()) {
-        if (cmd.compare(0, strlen(EVENT_TOGGLE_MUTE), EVENT_TOGGLE_MUTE) == 0) {
+        if (cmd.compare(0, strlen(EVENT_TOGGLE_MUTE), EVENT_TOGGLE_MUTE) == 0 && m_click_to_mute) {
           m_pulseaudio->toggle_mute();
         } else if (cmd.compare(0, strlen(EVENT_VOLUME_UP), EVENT_VOLUME_UP) == 0) {
           // cap above 100 (~150)?


### PR DESCRIPTION
Option is called click-to-mute. Fixes #1521