### PR TITLE
Build releases with release tar ball

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,13 +129,18 @@ Find a more complete list on the [dedicated wiki page](https://github.com/jaagr/
 
 Please [report any problems](https://github.com/jaagr/polybar/issues/new/choose) you run into when building the project.
 
-  ~~~ sh
-  $ git clone --branch 3.3 --recursive https://github.com/jaagr/polybar
-  $ mkdir polybar/build
-  $ cd polybar/build
-  $ cmake ..
-  $ sudo make install
-  ~~~
+Download the `polybar-<version>.tar` for the version you want to build from the
+[release page](https://github.com/jaagr/polybar/releases), extract it with
+`tar xvf polybar-<version>.tar` and go into the extracted folder. There, run
+the following commands:
+
+```sh
+$ mkdir build
+$ cd build
+$ cmake ..
+$ make -j$(nproc)
+$ sudo make install
+```
 
 There's also a helper script available in the root folder:
 

--- a/contrib/polybar.aur/PKGBUILD
+++ b/contrib/polybar.aur/PKGBUILD
@@ -22,11 +22,10 @@ optdepends=("alsa-lib: alsa module support"
 makedepends=("cmake" "git" "python" "python2" "pkg-config")
 conflicts=("polybar-git")
 install="${pkgname}.install"
-source=("${pkgname}::git+${url}.git#tag=${pkgver}")
-md5sums=("SKIP")
+source=(${url}/releases/download/${pkgver}/polybar.tar)
+sha256sums=('647dde8fbf6690138b354bf538d1d97ba8c1743ff22314af4ee085e06a1f506a')
 
 prepare() {
-  git -C "${pkgname}" submodule update --init --recursive
   mkdir -p "${pkgname}/build"
 }
 


### PR DESCRIPTION
Since v3.1.0 we provide a tarball containing the repo and all submodules. This Adds documentation and changes the AUR PKGBUILD to use those archives. It's much easier for the users to not have to deal with git as well, it also saves time because cloning the repo is quite slow