### PR TITLE
github: Ask about regressions in bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -15,6 +15,10 @@ about: Create a report to help us improve
 
 *What actually happens*
 
+**Was it working before?**
+* Did you also experience this bug in an earlier version of polybar?
+* If no, what was the last version where this worked correctly?
+
 ## To Reproduce
 *A minimal but complete config with which the problem occurs:*
 ```dosini


### PR DESCRIPTION
Often it would be useful to know if something broke after an update or
if the bug was there from the beginning