### PR TITLE
feat: format-font

### DIFF
--- a/include/modules/meta/base.hpp
+++ b/include/modules/meta/base.hpp
@@ -74,6 +74,7 @@ namespace modules {
     size_t padding{0};
     size_t margin{0};
     int offset{0};
+    int font{0};
 
     string decorate(builder* builder, string output);
   };

--- a/src/modules/meta/base.cpp
+++ b/src/modules/meta/base.cpp
@@ -32,6 +32,9 @@ namespace modules {
     if (!ol.empty()) {
       builder->overline(ol);
     }
+    if(font > 0) {
+      builder->font(font);
+    }
     if (padding > 0) {
       builder->space(padding);
     }
@@ -56,6 +59,9 @@ namespace modules {
 
     if (padding > 0) {
       builder->space(padding);
+    }
+    if(font > 0) {
+      builder->font_close();
     }
     if (!ol.empty()) {
       builder->overline_close();
@@ -95,6 +101,7 @@ namespace modules {
     format->padding = m_conf.get(m_modname, name + "-padding", formatdef("padding", format->padding));
     format->margin = m_conf.get(m_modname, name + "-margin", formatdef("margin", format->margin));
     format->offset = m_conf.get(m_modname, name + "-offset", formatdef("offset", format->offset));
+    format->font = m_conf.get(m_modname, name + "-font", formatdef("font", format->font));
     format->tags.swap(tags);
 
     try {

--- a/src/modules/mpd.cpp
+++ b/src/modules/mpd.cpp
@@ -39,6 +39,7 @@ namespace modules {
       mod_format->padding = m_conf.get(name(), FORMAT_ONLINE + "-padding"s, mod_format->padding);
       mod_format->margin = m_conf.get(name(), FORMAT_ONLINE + "-margin"s, mod_format->margin);
       mod_format->offset = m_conf.get(name(), FORMAT_ONLINE + "-offset"s, mod_format->offset);
+      mod_format->font = m_conf.get(name(), FORMAT_ONLINE + "-font"s, mod_format->font);
 
       try {
         mod_format->prefix = load_label(m_conf, name(), FORMAT_ONLINE + "-prefix"s);


### PR DESCRIPTION
Closing the oldest open issue. Not really anything groundbreaking in there. The changes to the mpd module are needed because of the fix for property inheritance for mpd in #868.

I used the following config to quickly test this feature.
```dosini
[bar/example]
font-0 = Noto Sans Mono:style=Regular:size=12
font-1 = Noto Sans Mono:style=Regular:size=22

modules-left = text text2

[module/text]
type = custom/text
content = Text %{T1} small
content-font = 2

[module/text2]
type = custom/text
content = Text small
```

Resolves #19