### PR TITLE
signal_emitter: Don't swallow exceptions

### DIFF
--- a/include/events/signal_emitter.hpp
+++ b/include/events/signal_emitter.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "common.hpp"
+#include "components/logger.hpp"
 #include "events/signal_receiver.hpp"
 
 POLYBAR_NS
@@ -25,12 +26,15 @@ class signal_emitter {
   template <typename Signal>
   bool emit(const Signal& sig) {
     try {
-      for (auto&& item : g_signal_receivers.at(id<Signal>())) {
-        if (item.second->on(sig)) {
-          return true;
+      if (g_signal_receivers.find(id<Signal>()) != g_signal_receivers.end()) {
+        for (auto&& item : g_signal_receivers.at(id<Signal>())) {
+          if (item.second->on(sig)) {
+            return true;
+          }
         }
       }
-    } catch (...) {
+    } catch (const std::exception& e) {
+      logger::make().err(e.what());
     }
 
     return false;


### PR DESCRIPTION
If any signal receiver throws an exception for any reason after
receiving a signal, no one would find out about it because the signal
emitter just ignored exceptions

Also actually delivering the signal caused some exceptions because not
all signals have a receiver.

I hope this doesn't bring too many polybar errors to light that were swallowed before

Resolves #1593