### PR TITLE
fix(fs): Calculate free bytes properly

### DIFF
--- a/include/modules/fs.hpp
+++ b/include/modules/fs.hpp
@@ -17,10 +17,10 @@ namespace modules {
     string type;
     string fsname;
 
-    unsigned long long bytes_free{0ULL};
-    unsigned long long bytes_used{0ULL};
-    unsigned long long bytes_avail{0ULL};
-    unsigned long long bytes_total{0ULL};
+    uint64_t bytes_free{0ULL};
+    uint64_t bytes_used{0ULL};
+    uint64_t bytes_avail{0ULL};
+    uint64_t bytes_total{0ULL};
 
     int percentage_free{0};
     int percentage_used{0};

--- a/src/modules/fs.cpp
+++ b/src/modules/fs.cpp
@@ -98,7 +98,7 @@ namespace modules {
 
         // see: http://en.cppreference.com/w/cpp/filesystem/space
         mount->bytes_total = buffer.f_frsize * buffer.f_blocks;
-        mount->bytes_free = buffer.f_bsize * buffer.f_bfree;
+        mount->bytes_free = buffer.f_frsize * buffer.f_bfree;
         mount->bytes_used = mount->bytes_total - mount->bytes_free;
         mount->bytes_avail = buffer.f_frsize * buffer.f_bavail;
 


### PR DESCRIPTION
Seems this was missed in a682d2af91881fa775e265520f7f820cb71dc707

This is now also consistent with what df does

Closes #743