### PR TITLE
fix(randr): Check if there is a primary monitor

### DIFF
--- a/src/x11/extensions/randr.cpp
+++ b/src/x11/extensions/randr.cpp
@@ -102,9 +102,13 @@ namespace randr_util {
     }
 #endif
     auto primary_output = conn.get_output_primary(root).output();
-    auto primary_info = conn.get_output_info(primary_output);
-    auto name_iter = primary_info.name();
-    string primary_name = {name_iter.begin(), name_iter.end()};
+    string primary_name{""};
+
+    if (primary_output != XCB_NONE) {
+      auto primary_info = conn.get_output_info(primary_output);
+      auto name_iter = primary_info.name();
+      primary_name = {name_iter.begin(), name_iter.end()};
+    }
 
     for (auto&& output : conn.get_screen_resources(root).outputs()) {
       try {

--- a/src/x11/extensions/randr.cpp
+++ b/src/x11/extensions/randr.cpp
@@ -102,7 +102,7 @@ namespace randr_util {
     }
 #endif
     auto primary_output = conn.get_output_primary(root).output();
-    string primary_name{""};
+    string primary_name{};
 
     if (primary_output != XCB_NONE) {
       auto primary_info = conn.get_output_info(primary_output);


### PR DESCRIPTION
primary_info.name() throws an error if get_output_info is called with
XCB_NONE

Fixes #1620