### PR TITLE
Test compilation fails again

### DIFF
--- a/tests/unit_tests/components/bar.cpp
+++ b/tests/unit_tests/components/bar.cpp
@@ -35,10 +35,10 @@ vector<pair<double, string>> to_pixels_with_offset_list = {
   {0, "1%:-100"},
 };
 
-INSTANTIATE_TEST_CASE_P(NoOffset, GeomFormatToPixelsTest,
+INSTANTIATE_TEST_SUITE_P(NoOffset, GeomFormatToPixelsTest,
     ::testing::ValuesIn(to_pixels_no_offset_list));
 
-INSTANTIATE_TEST_CASE_P(WithOffset, GeomFormatToPixelsTest,
+INSTANTIATE_TEST_SUITE_P(WithOffset, GeomFormatToPixelsTest,
     ::testing::ValuesIn(to_pixels_with_offset_list));
 
 TEST_P(GeomFormatToPixelsTest, correctness) {

--- a/tests/unit_tests/components/bar.cpp
+++ b/tests/unit_tests/components/bar.cpp
@@ -36,10 +36,10 @@ vector<pair<double, string>> to_pixels_with_offset_list = {
 };
 
 INSTANTIATE_TEST_CASE_P(NoOffset, GeomFormatToPixelsTest,
-    ::testing::ValuesIn(to_pixels_no_offset_list),);
+    ::testing::ValuesIn(to_pixels_no_offset_list));
 
 INSTANTIATE_TEST_CASE_P(WithOffset, GeomFormatToPixelsTest,
-    ::testing::ValuesIn(to_pixels_with_offset_list),);
+    ::testing::ValuesIn(to_pixels_with_offset_list));
 
 TEST_P(GeomFormatToPixelsTest, correctness) {
   double exp = GetParam().first;

--- a/tests/unit_tests/components/builder.cpp
+++ b/tests/unit_tests/components/builder.cpp
@@ -51,7 +51,7 @@ vector<pair<string, tuple<string, bool, int>>> get_label_text_list = {
   {"abcdefgh", make_tuple("abcdefgh", true, 8)},
 };
 
-INSTANTIATE_TEST_CASE_P(Inst, GetLabelTextTest,
+INSTANTIATE_TEST_SUITE_P(Inst, GetLabelTextTest,
     ::testing::ValuesIn(get_label_text_list));
 
 TEST_P(GetLabelTextTest, correctness) {

--- a/tests/unit_tests/components/builder.cpp
+++ b/tests/unit_tests/components/builder.cpp
@@ -52,7 +52,7 @@ vector<pair<string, tuple<string, bool, int>>> get_label_text_list = {
 };
 
 INSTANTIATE_TEST_CASE_P(Inst, GetLabelTextTest,
-    ::testing::ValuesIn(get_label_text_list),);
+    ::testing::ValuesIn(get_label_text_list));
 
 TEST_P(GetLabelTextTest, correctness) {
   label_t m_label = factory_util::shared<label>(get<0>(GetParam().second));

--- a/tests/unit_tests/components/parser.cpp
+++ b/tests/unit_tests/components/parser.cpp
@@ -27,7 +27,7 @@ vector<pair<string, string>> parse_action_cmd_list = {
   {"\\:\\:\\:", ":\\:\\:\\::\\abc"},
 };
 
-INSTANTIATE_TEST_CASE_P(Inst, ParseActionCmd,
+INSTANTIATE_TEST_SUITE_P(Inst, ParseActionCmd,
     ::testing::ValuesIn(parse_action_cmd_list));
 
 TEST_P(ParseActionCmd, correctness) {

--- a/tests/unit_tests/components/parser.cpp
+++ b/tests/unit_tests/components/parser.cpp
@@ -28,7 +28,7 @@ vector<pair<string, string>> parse_action_cmd_list = {
 };
 
 INSTANTIATE_TEST_CASE_P(Inst, ParseActionCmd,
-    ::testing::ValuesIn(parse_action_cmd_list),);
+    ::testing::ValuesIn(parse_action_cmd_list));
 
 TEST_P(ParseActionCmd, correctness) {
   auto input = GetParam().second;


### PR DESCRIPTION
The `INSTANTIATE_TEST_CASE_P` macro when used with zero variadic arguments required a comma after the last argument to not generate any warnings, now it generates errors when there is a comma.