### PR TITLE
Update readme on installing example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,11 +159,7 @@ Run the following inside the build directory:
 ~~~ sh
 $ make userconfig
 ~~~
-Or you can copy the example config from `/usr/share/doc/polybar/config` like so
-
-~~~ sh
-$ cp /usr/share/doc/polybar/config $XDG_CONFIG_HOME/polybar/config
-~~~
+Or you can copy the example config from `/usr/share/doc/polybar/config` or ` /usr/local/share/doc/polybar/config` (depending on your install parameters)
 
 #### Launch the example bar
   ~~~ sh

--- a/README.md
+++ b/README.md
@@ -159,6 +159,11 @@ Run the following inside the build directory:
 ~~~ sh
 $ make userconfig
 ~~~
+Or you can copy the example config from `/usr/share/doc/polybar/config` like so
+
+~~~ sh
+$ cp /usr/share/doc/polybar/config $XDG_CONFIG_HOME/polybar/config
+~~~
 
 #### Launch the example bar
   ~~~ sh


### PR DESCRIPTION
IF you isntall via a package manager, it's a bit trickier to get the default config, I found myself reading the sourcecode for the makefile to figure out where it came from.

On arch, at least, a copy is stored in `/usr/share/doc/polybar/config`, I assume this is the same for most distros, so I figured i'd add that snippet to the readme