### PR TITLE
Fix data race in get_output/update

### DIFF
--- a/include/modules/meta/base.hpp
+++ b/include/modules/meta/base.hpp
@@ -144,8 +144,7 @@ namespace modules {
     const logger& m_log;
     const config& m_conf;
 
-    mutex m_buildlock;
-    mutex m_updatelock;
+    mutex m_contentlock;
     mutex m_sleeplock;
     std::condition_variable m_sleephandler;
 

--- a/include/modules/meta/base.inl
+++ b/include/modules/meta/base.inl
@@ -54,9 +54,7 @@ namespace modules {
     m_log.info("%s: Stopping", name());
     m_enabled = false;
 
-    std::lock(m_buildlock, m_updatelock);
-    std::lock_guard<std::mutex> guard_a(m_buildlock, std::adopt_lock);
-    std::lock_guard<std::mutex> guard_b(m_updatelock, std::adopt_lock);
+    std::lock_guard<std::mutex> guard_b(m_contentlock);
     {
       CAST_MOD(Impl)->wakeup();
       CAST_MOD(Impl)->teardown();
@@ -122,7 +120,8 @@ namespace modules {
 
   template <typename Impl>
   string module<Impl>::get_output() {
-    std::lock_guard<std::mutex> guard(m_buildlock);
+    std::lock_guard<std::mutex> guard_b(m_contentlock);
+
     auto format_name = CONST_MOD(Impl).get_format();
     auto format = m_formatter->get(format_name);
     bool no_tag_built{true};

--- a/include/modules/meta/event_module.hpp
+++ b/include/modules/meta/event_module.hpp
@@ -19,13 +19,13 @@ namespace modules {
       this->m_log.trace("%s: Thread id = %i", this->name(), concurrency_util::thread_id(this_thread::get_id()));
       try {
         // warm up module output before entering the loop
-        std::unique_lock<std::mutex> guard(this->m_updatelock);
+        std::unique_lock<std::mutex> guard(this->m_contentlock);
         CAST_MOD(Impl)->update();
         CAST_MOD(Impl)->broadcast();
         guard.unlock();
 
         const auto check = [&]() -> bool {
-          std::lock_guard<std::mutex> guard(this->m_updatelock);
+          std::lock_guard<std::mutex> guard(this->m_contentlock);
           return CAST_MOD(Impl)->has_event() && CAST_MOD(Impl)->update();
         };
 

--- a/include/modules/meta/inotify_module.hpp
+++ b/include/modules/meta/inotify_module.hpp
@@ -20,13 +20,13 @@ namespace modules {
       this->m_log.trace("%s: Thread id = %i", this->name(), concurrency_util::thread_id(this_thread::get_id()));
       try {
         // Warm up module output before entering the loop
-        std::unique_lock<std::mutex> guard(this->m_updatelock);
+        std::unique_lock<std::mutex> guard(this->m_contentlock);
         CAST_MOD(Impl)->on_event(nullptr);
         CAST_MOD(Impl)->broadcast();
         guard.unlock();
 
         while (this->running()) {
-          std::lock_guard<std::mutex> guard(this->m_updatelock);
+          std::lock_guard<std::mutex> guard(this->m_contentlock);
           CAST_MOD(Impl)->poll_events();
         }
       } catch (const module_error& err) {

--- a/include/modules/meta/timer_module.hpp
+++ b/include/modules/meta/timer_module.hpp
@@ -21,7 +21,7 @@ namespace modules {
       this->m_log.trace("%s: Thread id = %i", this->name(), concurrency_util::thread_id(this_thread::get_id()));
 
       const auto check = [&]() -> bool {
-        std::unique_lock<std::mutex> guard(this->m_updatelock);
+        std::unique_lock<std::mutex> guard(this->m_contentlock);
         return CAST_MOD(Impl)->update();
       };
 

--- a/src/modules/xwindow.cpp
+++ b/src/modules/xwindow.cpp
@@ -105,9 +105,7 @@ namespace modules {
    * Update the currently active window and query its title
    */
   void xwindow_module::update(bool force) {
-    std::lock(m_buildlock, m_updatelock);
-    std::lock_guard<std::mutex> guard_a(m_buildlock, std::adopt_lock);
-    std::lock_guard<std::mutex> guard_b(m_updatelock, std::adopt_lock);
+    std::lock_guard<std::mutex> guard_b(m_contentlock);
 
     xcb_window_t win;
 


### PR DESCRIPTION
Thread sanitizer reported a data race for cpu_module and memory_module, my guess is that they should show up eventually for all modules that update their content frequently - battery as well?

Thread sanitizer output for cpu_module:
https://pastebin.com/Raj6hLbh

Since we would end up with always locking buildlock and updatelock, buildlock was removed and the other one renamed.