### PR TITLE
Add filesystem module mount labels #1214

### DIFF
--- a/include/modules/fs.hpp
+++ b/include/modules/fs.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "components/config.hpp"
-#include "settings.hpp"
 #include "modules/meta/timer_module.hpp"
+#include "settings.hpp"
 
 POLYBAR_NS
 
@@ -16,6 +16,7 @@ namespace modules {
 
     string type;
     string fsname;
+    label_t label;
 
     uint64_t bytes_free{0ULL};
     uint64_t bytes_used{0ULL};
@@ -25,7 +26,8 @@ namespace modules {
     int percentage_free{0};
     int percentage_used{0};
 
-    explicit fs_mount(const string& mountpoint, bool mounted = false) : mountpoint(mountpoint), mounted(mounted) {}
+    explicit fs_mount(string mountpoint, label_t label = nullptr, bool mounted = false)
+        : mountpoint(move(mountpoint)), mounted(mounted), label(move(label)) {}
   };
 
   using fs_mount_t = unique_ptr<fs_mount>;
@@ -57,7 +59,12 @@ namespace modules {
     progressbar_t m_barfree;
     ramp_t m_rampcapacity;
 
+    label_t m_default_mounted_name;
+    label_t m_default_unmounted_name;
+
     vector<string> m_mountpoints;
+    vector<label_t> m_mountpoints_label_mounted{};
+    vector<label_t> m_mountpoints_label_unmounted{};
     vector<fs_mount_t> m_mounts;
     bool m_fixed{false};
     bool m_remove_unmounted{false};
@@ -66,6 +73,6 @@ namespace modules {
     // used while formatting output
     size_t m_index{0_z};
   };
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/src/modules/fs.cpp
+++ b/src/modules/fs.cpp
@@ -26,7 +26,18 @@ namespace modules {
    * setting up required components
    */
   fs_module::fs_module(const bar_settings& bar, string name_) : timer_module<fs_module>(bar, move(name_)) {
+    m_default_mounted_name = load_optional_label(m_conf, name(), "label-mounted-default", "%mountpoint%");
+    m_default_unmounted_name = load_optional_label(m_conf, name(), "label-unmounted-default", "%mountpoint% is not mounted");
+
     m_mountpoints = m_conf.get_list(name(), "mount");
+    m_mountpoints_label_mounted.reserve(m_mountpoints.size());
+
+    for (std::size_t i = 0; i < m_mountpoints.size(); ++i) {
+      m_mountpoints_label_mounted.push_back(load_optional_label(m_conf, name(), "label-mounted-" + std::to_string(i)));
+      m_mountpoints_label_unmounted.push_back(
+          load_optional_label(m_conf, name(), "label-unmounted-" + std::to_string(i)));
+    }
+
     m_remove_unmounted = m_conf.get(name(), "remove-unmounted", m_remove_unmounted);
     m_fixed = m_conf.get(name(), "fixed-values", m_fixed);
     m_spacing = m_conf.get(name(), "spacing", m_spacing);
@@ -78,12 +89,16 @@ namespace modules {
       }
     }
 
+    auto mounted_label_it = m_mountpoints_label_mounted.cbegin();
+    auto unmounted_label_it = m_mountpoints_label_unmounted.cbegin();
     // Get data for defined mountpoints
     for (auto&& mountpoint : m_mountpoints) {
       auto details = std::find_if(mountinfo.begin(), mountinfo.end(),
           [&](const vector<string>& m) { return m.size() > 4 && m[4] == mountpoint; });
 
-      m_mounts.emplace_back(new fs_mount{mountpoint, details != mountinfo.end()});
+      bool mounted = details != mountinfo.end();
+
+      m_mounts.emplace_back(new fs_mount{mountpoint, mounted ? *mounted_label_it : *unmounted_label_it, mounted});
       struct statvfs buffer {};
 
       if (!m_mounts.back()->mounted) {
@@ -102,9 +117,14 @@ namespace modules {
         mount->bytes_used = mount->bytes_total - mount->bytes_free;
         mount->bytes_avail = buffer.f_frsize * buffer.f_bavail;
 
-        mount->percentage_free = math_util::percentage<double>(mount->bytes_avail, mount->bytes_used + mount->bytes_avail);
-        mount->percentage_used = math_util::percentage<double>(mount->bytes_used, mount->bytes_used + mount->bytes_avail);
+        mount->percentage_free =
+            math_util::percentage<double>(mount->bytes_avail, mount->bytes_used + mount->bytes_avail);
+        mount->percentage_used =
+            math_util::percentage<double>(mount->bytes_used, mount->bytes_used + mount->bytes_avail);
       }
+
+      ++mounted_label_it;
+      ++unmounted_label_it;
     }
 
     if (m_remove_unmounted) {
@@ -150,6 +170,29 @@ namespace modules {
   bool fs_module::build(builder* builder, const string& tag) const {
     auto& mount = m_mounts[m_index];
 
+    auto build_mountpoint_name = [&mount](const label_t& default_label) -> string {
+      auto apply = [&mount](auto& label) -> string {
+        label->reset_tokens();
+        label->replace_token("%mountpoint%", mount->mountpoint);
+        if (mount->mounted) {
+          label->replace_token("%type%", mount->type);
+          label->replace_token("%fsname%", mount->fsname);
+          label->replace_token("%percentage_free%", to_string(mount->percentage_free));
+          label->replace_token("%percentage_used%", to_string(mount->percentage_used));
+        }
+        return label->get();
+      };
+
+      std::string name;
+      if (*mount->label) {
+        name = apply(mount->label);
+      } else if (*default_label) {
+        name = apply(default_label);
+      }
+
+      return name;
+    };
+
     if (tag == TAG_BAR_FREE) {
       builder->node(m_barfree->output(mount->percentage_free));
     } else if (tag == TAG_BAR_USED) {
@@ -158,6 +201,7 @@ namespace modules {
       builder->node(m_rampcapacity->get_by_percentage(mount->percentage_free));
     } else if (tag == TAG_LABEL_MOUNTED) {
       m_labelmounted->reset_tokens();
+      m_labelmounted->replace_token("%label%", build_mountpoint_name(m_default_mounted_name));
       m_labelmounted->replace_token("%mountpoint%", mount->mountpoint);
       m_labelmounted->replace_token("%type%", mount->type);
       m_labelmounted->replace_token("%fsname%", mount->fsname);
@@ -173,6 +217,7 @@ namespace modules {
     } else if (tag == TAG_LABEL_UNMOUNTED) {
       m_labelunmounted->reset_tokens();
       m_labelunmounted->replace_token("%mountpoint%", mount->mountpoint);
+      m_labelunmounted->replace_token("%label%", build_mountpoint_name(m_default_unmounted_name));
       builder->node(m_labelunmounted);
     } else {
       return false;
@@ -180,6 +225,6 @@ namespace modules {
 
     return true;
   }
-}
+}  // namespace modules
 
 POLYBAR_NS_END


### PR DESCRIPTION
Add feature requested in #1214. (Also related to #1292)

Each mountpoint can have two optionals labels (```label-mounted-*```), (```label-unmounted-*```).
As asked in https://github.com/jaagr/polybar/pull/1292#pullrequestreview-171328125:
- labels are optional, the default value is used if the label is not in the config.
- all tokens (except ```%label%```) are supported in ```label-mounted-*```, ```label-unmounted-*``` only supports ```%mountpoint%```.

Example with doc:

```
[module/filesystem]
type = internal/fs
interval = 1

; Available tokens:
;   %mountpoint%
;   %type%
;   %fsname%
;   %percentage_free%
;   %percentage_used%
;   %total%
;   %free%
;   %used%
; Default: %mountpoint%
label-mounted-default = "%mountpoint%"

; Available tokens:
;   %mountpoint%
; Default: %mountpoint% is not mounted
label-unmounted-default = "%mountpoint%"

mount-0 = /
; See label-mounted-default documentation
label-mounted-0 = "Root - %mountpoint%"

mount-1 = /home
; See label-mounted-default documentation
label-mounted-1 = "~"

mount-2 = /media
; See label-mounted-default documentation
label-mounted-2 = "Media"
; See label-unmounted-default documentation
label-unmounted-2 = "Media unmounted"

; Available tokens:
;   %mountpoint%
;   %label%
;   %type%
;   %fsname%
;   %percentage_free%
;   %percentage_used%
;   %total%
;   %free%
;   %used%
; Default: %mountpoint% %percentage_free%%
label-mounted = %{F#0a81f5}%label%%{F-}: %percentage_used%%
; Available tokens:
;   %mountpoint%
;   %label%
; Default: %mountpoint% is not mounted
label-unmounted = %label%
label-unmounted-foreground = ${colors.foreground-alt}
```
