### PR TITLE
Fix tray offset #1666

### DIFF
--- a/include/utils/math.hpp
+++ b/include/utils/math.hpp
@@ -56,7 +56,18 @@ namespace math_util {
   }
 
   /**
-   * Get value for percentage of `max_value`
+   * Get value for signed percentage of `max_value` (cap between -max_value and max_value)
+   */
+  template <typename ValueType, typename ReturnType = int>
+  ReturnType signed_percentage_to_value(ValueType signed_percentage, ValueType max_value) {
+    if (std::is_integral<ReturnType>())
+      return cap<ReturnType>(signed_percentage * max_value / 100.0f + 0.5f, -max_value, max_value);
+    else
+      return cap<ReturnType>(signed_percentage * max_value / 100.0f, -max_value, max_value);
+  }
+
+  /**
+   * Get value for percentage of `max_value` (cap between 0 and max_value)
    */
   template <typename ValueType, typename ReturnType = int>
   ReturnType percentage_to_value(ValueType percentage, ValueType max_value) {

--- a/src/x11/tray_manager.cpp
+++ b/src/x11/tray_manager.cpp
@@ -150,17 +150,17 @@ void tray_manager::setup(const bar_settings& bar_opts) {
 
   if (offset_x != 0 && offset_x_def.find('%') != string::npos) {
     if (m_opts.detached) {
-      offset_x = math_util::percentage_to_value<int>(offset_x, bar_opts.monitor->w);
+      offset_x = math_util::signed_percentage_to_value<int>(offset_x, bar_opts.monitor->w);
     } else {
-      offset_x = math_util::percentage_to_value<int>(offset_x, inner_area.width);
+      offset_x = math_util::signed_percentage_to_value<int>(offset_x, inner_area.width);
     }
   }
 
   if (offset_y != 0 && offset_y_def.find('%') != string::npos) {
     if (m_opts.detached) {
-      offset_y = math_util::percentage_to_value<int>(offset_y, bar_opts.monitor->h);
+      offset_y = math_util::signed_percentage_to_value<int>(offset_y, bar_opts.monitor->h);
     } else {
-      offset_y = math_util::percentage_to_value<int>(offset_y, inner_area.height);
+      offset_y = math_util::signed_percentage_to_value<int>(offset_y, inner_area.height);
     }
   }
 


### PR DESCRIPTION
As reported in #1666, negative percentage in tray are ignored.

It seems that the function (```percentage_to_value```) used to compute the value from the percentage clamps the value between ```0``` and ```max_value```.
To fix this problem, I added a ```signed_percentage_to_value``` function which clamps the value between ```-max_value``` and ```max_value``` and so it allows percentage between -100% and 100%.

However, when I fixed this bug, I noticed something strange, is it okay that the bar stops where the tray is supposed to be without any offset (see image below)?
![image](https://user-images.githubusercontent.com/10365269/53691126-9eeed200-3d45-11e9-8ecf-7c35ce91c9db.png)

In the wiki it is written that only the content should be shifted, so I wonder if this is a bug.

Minimal config:
```
[bar/example]
width = 100%
height = 27

font-0 = fixed:pixelsize=10;1
font-1 = unifont:fontformat=truetype:size=8:antialias=false;0
font-2 = siji:pixelsize=10;1

modules-center = test

tray-position = right
tray-padding = 2
tray-detached = false
tray-offset-x = -10%
tray-background = #0063ff
border-size = 4
border-color = #00000000

background = #222
foreground = #dfdfdf

[module/test]
type = custom/text
content = Default

```

With ```tray-detached = true```, the behavior is as expected since the content of the bar is not shifted.
![image](https://user-images.githubusercontent.com/10365269/53691178-35bb8e80-3d46-11e9-8d4f-251556b031bf.png)

