### PR TITLE
Fix compilation with clang8 #1674

### DIFF
--- a/include/x11/tray_client.hpp
+++ b/include/x11/tray_client.hpp
@@ -14,8 +14,8 @@ struct xembed_data;
 class tray_client {
  public:
   explicit tray_client(connection& conn, xcb_window_t win, unsigned int w, unsigned int h);
-  tray_client(const tray_client& c) = default;
-  tray_client& operator=(tray_client& c) = default;
+  tray_client(const tray_client& c) = delete;
+  tray_client& operator=(tray_client& c) = delete;
 
   ~tray_client();
 


### PR DESCRIPTION
This PR fixes #1674 by removing the copy ctor and assignment operator of `tray_client`.

Copy assignment was marked as defaulted however as stated in the C++ standard:
> A defaulted copy/move assignment operator for class X is defined as deleted if X has:
> - […]
> -  non-static data member of reference type, or
> - […]
>
> § 12.8

Since a reference can't be reassigned, I just marked this operator as explicitly deleted.

The copy ctor was also defaulted and it is well-formed but the dtor unembed the window so copying that class may cause bugs, so I also marked it as explicitly deleted. Another solution if copying this class is needed is to do the "unembeding" in a custom deleter of `m_xembed`.
