### PR TITLE
fix(controller): ignore SIGUSR1 until polybar is fully reloaded.

### DIFF
--- a/src/components/controller.cpp
+++ b/src/components/controller.cpp
@@ -26,6 +26,10 @@ sig_atomic_t g_reload{0};
 sig_atomic_t g_terminate{0};
 
 void interrupt_handler(int signum) {
+  if (g_reload || g_terminate) {
+    return;
+  }
+
   g_terminate = 1;
   g_reload = (signum == SIGUSR1);
   if (write(g_eventpipe[PIPE_WRITE], &g_terminate, 1) == -1) {
@@ -122,6 +126,12 @@ controller::~controller() {
   signal(SIGINT, SIG_DFL);
   signal(SIGQUIT, SIG_DFL);
   signal(SIGTERM, SIG_DFL);
+  signal(SIGALRM, SIG_DFL);
+
+  if (g_reload) {
+    // Cause SIGUSR1 to be ignored until registered in the new polybar process
+    signal(SIGUSR1, SIG_IGN);
+  }
 
   m_log.trace("controller: Detach signal receiver");
   m_sig.detach(this);


### PR DESCRIPTION
Fix #428.

To fix this bug, I chose to ignore signals in the handler if polybar is being killed/reloaded.
Moreover to avoid polybar from being killed by `SIGUSR1` during reloading, `SIGUSR1` is ignored until the signal is registered in the new polybar process.

As stated in `signal(7)` man page, the ignored signals are still ignored after a call to a function of the execvX family. 
> During an execve(2), the dispositions of handled signals are reset to the default;
       the dispositions of ignored signals are left unchanged.