### PR TITLE
Fix difference between real and displayed value in backlight module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ addons:
         - libxcb-util0-dev
         - python-xcbgen
         - xcb-proto
+        - libudev-dev
       - &optional_deps
         - libxcb-xkb-dev
         - libxcb-cursor-dev

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ A compiler with C++14 support ([clang-3.4+](http://llvm.org/releases/download.ht
 - `xcb-proto`
 - `xcb-util-image`
 - `xcb-util-wm`
+- `libudev`
 
 **Optional dependencies:**
 - `xcb-util-cursor` *required for the `cursor-click` and `cursor-scroll` settings*

--- a/cmake/03-libs.cmake
+++ b/cmake/03-libs.cmake
@@ -6,6 +6,7 @@ find_package(Threads REQUIRED)
 list(APPEND libs ${CMAKE_THREAD_LIBS_INIT})
 
 querylib(TRUE "pkg-config" cairo-fc libs dirs)
+querylib(TRUE "pkg-config" libudev libs dirs)
 
 querylib(ENABLE_ALSA "pkg-config" alsa libs dirs)
 querylib(ENABLE_CURL "pkg-config" libcurl libs dirs)

--- a/contrib/polybar-git.aur/PKGBUILD
+++ b/contrib/polybar-git.aur/PKGBUILD
@@ -8,7 +8,7 @@ pkgdesc="A fast and easy-to-use status bar"
 arch=("i686" "x86_64")
 url="https://github.com/jaagr/polybar"
 license=("MIT")
-depends=("cairo" "xcb-util-image" "xcb-util-wm" "xcb-util-xrm" "xcb-util-cursor")
+depends=("cairo" "xcb-util-image" "xcb-util-wm" "xcb-util-xrm" "xcb-util-cursor" "udev")
 optdepends=("alsa-lib: alsa module support"
             "pulseaudio: pulseaudio module support"
             "libmpdclient: mpd module support"

--- a/contrib/polybar.aur/PKGBUILD
+++ b/contrib/polybar.aur/PKGBUILD
@@ -7,7 +7,7 @@ pkgdesc="A fast and easy-to-use status bar"
 arch=("i686" "x86_64")
 url="https://github.com/jaagr/polybar"
 license=("MIT")
-depends=("cairo" "xcb-util-image" "xcb-util-wm" "xcb-util-xrm" "xcb-util-cursor")
+depends=("cairo" "xcb-util-image" "xcb-util-wm" "xcb-util-xrm" "xcb-util-cursor" "udev")
 optdepends=("alsa-lib: alsa module support"
             "pulseaudio: pulseaudio module support"
             "libmpdclient: mpd module support"

--- a/contrib/rpm/polybar.spec
+++ b/contrib/rpm/polybar.spec
@@ -28,6 +28,7 @@ BuildRequires:  pkgconfig(python)
 BuildRequires:  pkgconfig(xcb)
 BuildRequires:  pkgconfig(xcb-proto)
 BuildRequires:  pkgconfig(xcb-util)
+BuildRequires:  pkgconfig(libudev)
 %if 0%{?suse_version} <= 1315
 BuildRequires:  i3-devel
 %else

--- a/include/modules/backlight.hpp
+++ b/include/modules/backlight.hpp
@@ -1,27 +1,18 @@
 #pragma once
 
 #include "components/config.hpp"
+#include "modules/meta/udev_module.hpp"
 #include "settings.hpp"
-#include "modules/meta/inotify_module.hpp"
 
 POLYBAR_NS
 
 namespace modules {
-  class backlight_module : public inotify_module<backlight_module> {
-   public:
-    struct brightness_handle {
-      void filepath(const string& path);
-      float read() const;
-
-     private:
-      string m_path;
-    };
-
+  class backlight_module : public udev_module<backlight_module> {
    public:
     explicit backlight_module(const bar_settings&, string);
 
     void idle();
-    bool on_event(inotify_event* event);
+    bool on_event(udev_event&& event);
     bool build(builder* builder, const string& tag) const;
 
    private:
@@ -33,11 +24,10 @@ namespace modules {
     label_t m_label;
     progressbar_t m_progressbar;
 
-    brightness_handle m_val;
-    brightness_handle m_max;
+    string m_card;
 
     int m_percentage = 0;
   };
-}
+}  // namespace modules
 
 POLYBAR_NS_END

--- a/include/modules/meta/udev_module.hpp
+++ b/include/modules/meta/udev_module.hpp
@@ -1,0 +1,69 @@
+#ifndef POLYBAR_UDEV_MODULE_HPP
+#define POLYBAR_UDEV_MODULE_HPP
+
+#include "components/builder.hpp"
+#include "modules/meta/base.hpp"
+#include "utils/udev.hpp"
+
+POLYBAR_NS
+
+namespace modules {
+  template <class Impl>
+  class udev_module : public module<Impl> {
+   public:
+    using module<Impl>::module;
+
+    void start() {
+      this->m_mainthread = thread(&udev_module::runner, this);
+    }
+    void watch(string&& subsystem) {
+      m_watch = udev_util::make_watch(move(subsystem));
+    }
+
+    void idle() {
+      this->sleep(200ms);
+    }
+
+    void poll_events() {
+      while (this->running()) {
+        if (m_watch->poll()) {
+          auto event = m_watch->get_event();
+
+          if (CAST_MOD(Impl)->on_event(move(event))) {
+            CAST_MOD(Impl)->broadcast();
+          }
+
+          CAST_MOD(Impl)->idle();
+          return;
+        }
+
+        if (!this->running())
+          break;
+
+        CAST_MOD(Impl)->idle();
+      }
+    }
+
+    void runner() {
+      this->m_log.trace("%s: Thread id = %i", this->name(), concurrency_util::thread_id(this_thread::get_id()));
+      m_watch->attach();
+      try {
+        while (this->running()) {
+          std::lock_guard<std::mutex> guard(this->m_updatelock);
+          CAST_MOD(Impl)->poll_events();
+        }
+      } catch (const module_error& err) {
+        CAST_MOD(Impl)->halt(err.what());
+      } catch (const std::exception& err) {
+        CAST_MOD(Impl)->halt(err.what());
+      }
+    }
+
+   private:
+    unique_ptr<udev_watch> m_watch;
+  };
+}  // namespace modules
+
+POLYBAR_NS_END
+
+#endif  // POLYBAR_UDEV_MODULE_HPP

--- a/include/utils/udev.hpp
+++ b/include/utils/udev.hpp
@@ -72,6 +72,11 @@ class udev_device {
    */
   const char* get_devtype() const;
 
+  /**
+   * Returns the action of the device (in case of an event)
+   */
+  const char* get_action() const;
+
  private:
   ::udev_device* m_dev = nullptr;
 };

--- a/include/utils/udev.hpp
+++ b/include/utils/udev.hpp
@@ -1,0 +1,122 @@
+#pragma once
+
+#include <memory>
+
+#include "common.hpp"
+#include "errors.hpp"
+#include "utils/factory.hpp"
+
+struct udev;
+struct udev_device;
+struct udev_monitor;
+
+POLYBAR_NS
+
+DEFINE_ERROR(udev_error);
+
+class udev_connection {
+ public:
+  using make_type = udev_connection&;
+
+  static make_type make();
+
+  udev_connection();
+
+  udev* conn;
+};
+
+class udev_device {
+ public:
+  udev_device() = default;
+  explicit udev_device(::udev_device* dev) noexcept : m_dev{dev} {}
+  udev_device(const udev_device&) = delete;
+  udev_device(udev_device&& rhs) noexcept;
+
+  ~udev_device();
+
+  udev_device& operator=(const udev_device&) noexcept = delete;
+  udev_device& operator=(udev_device&& rhs) noexcept;
+
+  /**
+   * Returns true if the device is valid
+   */
+  explicit operator bool() const {
+    return m_dev != nullptr;
+  }
+
+  /**
+   * Returns the value of the given attribute.
+   *
+   * For example if the device if brightness card (like intel_backlight),
+   * an attribute can be "actual_brightness" or "max_brightness"
+   */
+  const char* get_sysattr(const char* attr) const;
+
+  /**
+   * Overload for strings
+   */
+  const char* get_sysattr(const string& attr) const;
+
+  /**
+   * Returns the name of the device
+   */
+  const char* get_sysname() const;
+
+  /**
+   * Returns the path of the device
+   */
+  const char* get_syspath() const;
+
+  /**
+   * Returns the type of the device
+   */
+  const char* get_devtype() const;
+
+ private:
+  ::udev_device* m_dev = nullptr;
+};
+class udev_event {
+ public:
+  explicit udev_event(udev_device&& dev);
+
+  udev_device dev;
+};
+
+class udev_watch {
+ public:
+  explicit udev_watch(udev_connection& connection, string subsystem);
+
+  ~udev_watch();
+
+  /**
+   * Starts monitoring
+   */
+  void attach();
+
+  bool poll(int wait_ms = 1000) const;
+
+  udev_event get_event() const;
+
+  const string& subsystem() const {
+    return m_subsystem;
+  }
+
+ protected:
+  udev_monitor* m_monitor;
+  string m_subsystem;
+  int m_fd = -1;
+};
+
+namespace udev_util {
+  template <typename... Args>
+  decltype(auto) make_watch(Args&&... args) {
+    return factory_util::unique<udev_watch>(udev_connection::make(), forward<Args>(args)...);
+  }
+
+  /**
+   * Returns the device with the given sysname or an empty device if it doesn't exist.
+   */
+  udev_device get_device(const string& sysname);
+}  // namespace udev_util
+
+POLYBAR_NS_END

--- a/src/utils/udev.cpp
+++ b/src/utils/udev.cpp
@@ -1,0 +1,116 @@
+#include "utils/udev.hpp"
+
+#include <libudev.h>
+
+POLYBAR_NS
+
+udev_device udev_util::get_device(const std::string& sysname) {
+  udev_device device;
+
+  udev* udev = udev_connection::make().conn;
+  udev_list_entry* dev_list_entry;
+  udev_enumerate* enumerate = udev_enumerate_new(udev);
+
+  udev_enumerate_add_match_subsystem(enumerate, "backlight");
+  udev_enumerate_scan_devices(enumerate);
+
+  udev_list_entry* devices = udev_enumerate_get_list_entry(enumerate);
+
+  udev_list_entry_foreach(dev_list_entry, devices) {
+    const char* path = udev_list_entry_get_name(dev_list_entry);
+    ::udev_device* dev = udev_device_new_from_syspath(udev, path);
+
+    if (udev_device_get_sysname(dev) == sysname) {
+      device = udev_device{dev};
+      break;
+    }
+
+    udev_device_unref(dev);
+  }
+
+  udev_enumerate_unref(enumerate);
+
+  return device;
+}
+
+udev_device::~udev_device() {
+  udev_device_unref(m_dev);
+}
+
+udev_device::udev_device(udev_device&& rhs) noexcept : m_dev(std::exchange(rhs.m_dev, nullptr)) {}
+
+udev_device& udev_device::operator=(udev_device&& rhs) noexcept {
+  m_dev = std::exchange(rhs.m_dev, nullptr);
+  return *this;
+}
+
+const char* udev_device::get_sysattr(const char* attr) const {
+  return udev_device_get_sysattr_value(m_dev, attr);
+}
+
+const char* udev_device::get_sysattr(const std::string& attr) const {
+  return get_sysattr(attr.c_str());
+}
+
+const char* udev_device::get_sysname() const {
+  return udev_device_get_sysname(m_dev);
+}
+
+const char* udev_device::get_syspath() const {
+  return udev_device_get_syspath(m_dev);
+}
+
+const char* udev_device::get_devtype() const {
+  return udev_device_get_devtype(m_dev);
+}
+
+udev_event::udev_event(udev_device&& dev) : dev(move(dev)) {}
+
+void udev_watch::attach() {
+  if (udev_monitor_filter_add_match_subsystem_devtype(m_monitor, m_subsystem.c_str(), nullptr) < 0) {
+    throw udev_error("Failed to add filter to udev monitor");
+  }
+  if (udev_monitor_enable_receiving(m_monitor) < 0) {
+    throw udev_error("Failed to enabling udev monitor");
+  }
+  m_fd = udev_monitor_get_fd(m_monitor);
+}
+
+bool udev_watch::poll(int wait_ms) const {
+  fd_set fds;
+  timeval tv{0, wait_ms};
+  int ret;
+
+  FD_ZERO(&fds);
+  FD_SET(m_fd, &fds);
+
+  ret = ::select(m_fd + 1, &fds, nullptr, nullptr, &tv);
+  return ret > 0 && FD_ISSET(m_fd, &fds);
+}
+
+polybar::udev_event udev_watch::get_event() const {
+  return udev_event{udev_device{udev_monitor_receive_device(m_monitor)}};
+}
+
+udev_watch::~udev_watch() {
+  udev_monitor_unref(m_monitor);
+}
+
+udev_watch::udev_watch(polybar::udev_connection& connection, std::string subsystem)
+    : m_monitor(udev_monitor_new_from_netlink(connection.conn, "udev")), m_subsystem(move(subsystem)) {
+  if (!m_monitor) {
+    throw udev_error("Failde to create udev monitor");
+  }
+}
+
+polybar::udev_connection& udev_connection::make() {
+  return *factory_util::singleton<std::remove_reference_t<make_type>>();
+}
+
+udev_connection::udev_connection() : conn(udev_new()) {
+  if (!conn) {
+    throw udev_error("Failde to create udev connection");
+  }
+}
+
+POLYBAR_NS_END

--- a/src/utils/udev.cpp
+++ b/src/utils/udev.cpp
@@ -1,6 +1,7 @@
 #include "utils/udev.hpp"
 
 #include <libudev.h>
+#include <utils/udev.hpp>
 
 POLYBAR_NS
 
@@ -62,6 +63,10 @@ const char* udev_device::get_syspath() const {
 
 const char* udev_device::get_devtype() const {
   return udev_device_get_devtype(m_dev);
+}
+
+const char* udev_device::get_action() const {
+  return udev_device_get_action(m_dev);
 }
 
 udev_event::udev_event(udev_device&& dev) : dev(move(dev)) {}


### PR DESCRIPTION
Fix #1180.

WARNING :warning: :warning: : This PR is not only a bugfix, it also add a new feature in polybar :arrow_right: udev meta module.

As explained in #1180. Inotify event aren't guaranteed to work on sysfs (/sys/ /proc/ /dev/ …). So we can't use inotify to watch in theses directories. (citation of the man page below)

> Inotify reports only events that a user-space program triggers through the filesystem API. As a result, it does not catch remote events that occur on network filesystems. (Applications must fall back to polling the filesystem to catch such events.) Furthermore, various pseudo-filesystems such as /proc, /sys, and /dev/pts are not monitorable with inotify.

So as the man said, the filesystem can be polled to catch such events, but there is an API to monitor device :arrow_right: udev.
~~Since udev is quite "standard" among linux distributions and freebsd, I don't think this dependency will cause any problem.~~

~~If polybar uses this API, it could be easy to solve #469 #839 #1046 #1181 that may be linked to the aforementioned problem with inotify.~~

EDIT: To fix the power problems, it is more UPower that should be used (with dbus) sorry my bad.

 