### PR TITLE
fix(brightness): reading brightness in actual_brightness

### DIFF
--- a/cmake/02-opts.cmake
+++ b/cmake/02-opts.cmake
@@ -71,7 +71,7 @@ set(SETTING_PATH_ADAPTER "/sys/class/power_supply/%adapter%"
   CACHE STRING "Path to adapter")
 set(SETTING_PATH_BACKLIGHT_MAX "/sys/class/backlight/%card%/max_brightness"
   CACHE STRING "Path to file containing the maximum backlight value")
-set(SETTING_PATH_BACKLIGHT_VAL "/sys/class/backlight/%card%/brightness"
+set(SETTING_PATH_BACKLIGHT_VAL "/sys/class/backlight/%card%/actual_brightness"
   CACHE STRING "Path to file containing the current backlight value")
 set(SETTING_PATH_BATTERY "/sys/class/power_supply/%battery%"
   CACHE STRING "Path to battery")


### PR DESCRIPTION
Fix #1180.

As the kernel documentation said:
https://www.kernel.org/doc/Documentation/ABI/stable/sysfs-class-backlight
>  This file will also show the brightness level stored in the driver, which may not be the actual brightness (see actual_brightness).

Therefore the brightness value should be read in the `actual_brightness` file.