### PR TITLE
Apply clang-tidy modernize fixes

### DIFF
--- a/include/adapters/mpd.hpp
+++ b/include/adapters/mpd.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <mpd/client.h>
-#include <stdlib.h>
 #include <chrono>
 #include <csignal>
+#include <cstdlib>
 
 #include "common.hpp"
 #include "errors.hpp"

--- a/include/adapters/net.hpp
+++ b/include/adapters/net.hpp
@@ -74,7 +74,7 @@ namespace net {
   class network {
    public:
     explicit network(string interface);
-    virtual ~network() {}
+    virtual ~network() = default;
 
     virtual bool query(bool accumulate = false);
     virtual bool connected() const = 0;

--- a/include/adapters/pulseaudio.hpp
+++ b/include/adapters/pulseaudio.hpp
@@ -12,8 +12,8 @@
 struct pa_context;
 struct pa_threaded_mainloop;
 struct pa_cvolume;
-typedef struct pa_context pa_context;
-typedef struct pa_threaded_mainloop pa_threaded_mainloop;
+using pa_context = struct pa_context;
+using pa_threaded_mainloop = struct pa_threaded_mainloop;
 
 POLYBAR_NS
 class logger;

--- a/include/cairo/font.hpp
+++ b/include/cairo/font.hpp
@@ -25,7 +25,7 @@ namespace cairo {
   class font {
    public:
     explicit font(cairo_t* cairo, double offset) : m_cairo(cairo), m_offset(offset) {}
-    virtual ~font(){};
+    virtual ~font() = default;
 
     virtual string name() const = 0;
     virtual string file() const = 0;

--- a/include/cairo/surface.hpp
+++ b/include/cairo/surface.hpp
@@ -64,7 +64,7 @@ namespace cairo {
     explicit xcb_surface(xcb_connection_t* c, xcb_pixmap_t p, xcb_visualtype_t* v, int w, int h)
         : surface(cairo_xcb_surface_create(c, p, v, w, h)) {}
 
-    ~xcb_surface() override {}
+    ~xcb_surface() override = default;
 
     void set_drawable(xcb_drawable_t d, int w, int h) {
       cairo_surface_flush(m_s);

--- a/include/components/bar.hpp
+++ b/include/components/bar.hpp
@@ -62,7 +62,7 @@ class bar : public xpp::event::sink<evt::button_press, evt::expose, evt::propert
 
   explicit bar(connection&, signal_emitter&, const config&, const logger&, unique_ptr<screen>&&,
       unique_ptr<tray_manager>&&, unique_ptr<parser>&&, unique_ptr<taskqueue>&&, bool only_initialize_values);
-  ~bar();
+  ~bar() override;
 
   const bar_settings settings() const;
 
@@ -79,23 +79,23 @@ class bar : public xpp::event::sink<evt::button_press, evt::expose, evt::propert
   void reconfigure_wm_hints();
   void broadcast_visibility();
 
-  void handle(const evt::client_message& evt);
-  void handle(const evt::destroy_notify& evt);
-  void handle(const evt::enter_notify& evt);
-  void handle(const evt::leave_notify& evt);
-  void handle(const evt::motion_notify& evt);
-  void handle(const evt::button_press& evt);
-  void handle(const evt::expose& evt);
-  void handle(const evt::property_notify& evt);
-  void handle(const evt::configure_notify& evt);
+  void handle(const evt::client_message& evt) override;
+  void handle(const evt::destroy_notify& evt) override;
+  void handle(const evt::enter_notify& evt) override;
+  void handle(const evt::leave_notify& evt) override;
+  void handle(const evt::motion_notify& evt) override;
+  void handle(const evt::button_press& evt) override;
+  void handle(const evt::expose& evt) override;
+  void handle(const evt::property_notify& evt) override;
+  void handle(const evt::configure_notify& evt) override;
 
-  bool on(const signals::eventqueue::start&);
-  bool on(const signals::ui::unshade_window&);
-  bool on(const signals::ui::shade_window&);
-  bool on(const signals::ui::tick&);
-  bool on(const signals::ui::dim_window&);
+  bool on(const signals::eventqueue::start&) override;
+  bool on(const signals::ui::unshade_window&) override;
+  bool on(const signals::ui::shade_window&) override;
+  bool on(const signals::ui::tick&) override;
+  bool on(const signals::ui::dim_window&) override;
 #if WITH_XCURSOR
-  bool on(const signals::ui::cursor_change&);
+  bool on(const signals::ui::cursor_change&) override;
 #endif
 
  private:

--- a/include/components/config.hpp
+++ b/include/components/config.hpp
@@ -344,7 +344,7 @@ class config {
       m_log.info("File reference \"%s\" found", var);
       return convert<T>(string_util::trim(file_util::contents(var), '\n'));
     } else if (!fallback.empty()) {
-      m_log.warn("File reference \"%s\" not found, using defined fallback value \"%s\"", var, fallback);
+      m_log.warn(R"(File reference "%s" not found, using defined fallback value "%s")", var, fallback);
       return convert<T>(move(fallback));
     } else {
       throw value_error(sstream() << "The file \"" << var << "\" does not exist (no fallback set)");

--- a/include/components/controller.hpp
+++ b/include/components/controller.hpp
@@ -43,7 +43,7 @@ class controller : public signal_receiver<SIGN_PRIORITY_CONTROLLER, signals::eve
 
   explicit controller(connection&, signal_emitter&, const logger&, const config&, unique_ptr<bar>&&, unique_ptr<ipc>&&,
       unique_ptr<inotify_watch>&&);
-  ~controller();
+  ~controller() override;
 
   bool run(bool writeback, string snapshot_dst);
 
@@ -56,17 +56,17 @@ class controller : public signal_receiver<SIGN_PRIORITY_CONTROLLER, signals::eve
   void process_inputdata();
   bool process_update(bool force);
 
-  bool on(const signals::eventqueue::notify_change& evt);
-  bool on(const signals::eventqueue::notify_forcechange& evt);
-  bool on(const signals::eventqueue::exit_terminate& evt);
-  bool on(const signals::eventqueue::exit_reload& evt);
-  bool on(const signals::eventqueue::check_state& evt);
-  bool on(const signals::ui::ready& evt);
-  bool on(const signals::ui::button_press& evt);
-  bool on(const signals::ipc::action& evt);
-  bool on(const signals::ipc::command& evt);
-  bool on(const signals::ipc::hook& evt);
-  bool on(const signals::ui::update_background& evt);
+  bool on(const signals::eventqueue::notify_change& evt) override;
+  bool on(const signals::eventqueue::notify_forcechange& evt) override;
+  bool on(const signals::eventqueue::exit_terminate& evt) override;
+  bool on(const signals::eventqueue::exit_reload& evt) override;
+  bool on(const signals::eventqueue::check_state& evt) override;
+  bool on(const signals::ui::ready& evt) override;
+  bool on(const signals::ui::button_press& evt) override;
+  bool on(const signals::ipc::action& evt) override;
+  bool on(const signals::ipc::command& evt) override;
+  bool on(const signals::ipc::hook& evt) override;
+  bool on(const signals::ui::update_background& evt) override;
 
  private:
   connection& m_connection;

--- a/include/components/renderer.hpp
+++ b/include/components/renderer.hpp
@@ -43,7 +43,7 @@ class renderer
 
   explicit renderer(
       connection& conn, signal_emitter& sig, const config&, const logger& logger, const bar_settings& bar, background_manager& background_manager);
-  ~renderer();
+  ~renderer() override;
 
   xcb_window_t window() const;
   const vector<action_block> actions() const;
@@ -70,21 +70,21 @@ class renderer
   void flush(alignment a);
   void highlight_clickable_areas();
 
-  bool on(const signals::ui::request_snapshot& evt);
-  bool on(const signals::parser::change_background& evt);
-  bool on(const signals::parser::change_foreground& evt);
-  bool on(const signals::parser::change_underline& evt);
-  bool on(const signals::parser::change_overline& evt);
-  bool on(const signals::parser::change_font& evt);
-  bool on(const signals::parser::change_alignment& evt);
-  bool on(const signals::parser::reverse_colors&);
-  bool on(const signals::parser::offset_pixel& evt);
-  bool on(const signals::parser::attribute_set& evt);
-  bool on(const signals::parser::attribute_unset& evt);
-  bool on(const signals::parser::attribute_toggle& evt);
-  bool on(const signals::parser::action_begin& evt);
-  bool on(const signals::parser::action_end& evt);
-  bool on(const signals::parser::text& evt);
+  bool on(const signals::ui::request_snapshot& evt) override;
+  bool on(const signals::parser::change_background& evt) override;
+  bool on(const signals::parser::change_foreground& evt) override;
+  bool on(const signals::parser::change_underline& evt) override;
+  bool on(const signals::parser::change_overline& evt) override;
+  bool on(const signals::parser::change_font& evt) override;
+  bool on(const signals::parser::change_alignment& evt) override;
+  bool on(const signals::parser::reverse_colors&) override;
+  bool on(const signals::parser::offset_pixel& evt) override;
+  bool on(const signals::parser::attribute_set& evt) override;
+  bool on(const signals::parser::attribute_unset& evt) override;
+  bool on(const signals::parser::attribute_toggle& evt) override;
+  bool on(const signals::parser::action_begin& evt) override;
+  bool on(const signals::parser::action_end& evt) override;
+  bool on(const signals::parser::text& evt) override;
 
  protected:
   struct reserve_area {

--- a/include/components/screen.hpp
+++ b/include/components/screen.hpp
@@ -22,7 +22,7 @@ class screen : public xpp::event::sink<evt::randr_screen_change_notify> {
   static make_type make();
 
   explicit screen(connection& conn, signal_emitter& emitter, const logger& logger, const config& conf);
-  ~screen();
+  ~screen() override;
 
   struct size size() const {
     return m_size;
@@ -33,7 +33,7 @@ class screen : public xpp::event::sink<evt::randr_screen_change_notify> {
   }
 
  protected:
-  void handle(const evt::randr_screen_change_notify& evt);
+  void handle(const evt::randr_screen_change_notify& evt) override;
 
  private:
   connection& m_connection;

--- a/include/drawtypes/label.hpp
+++ b/include/drawtypes/label.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cassert>
+#include <utility>
 
 #include "common.hpp"
 #include "components/config.hpp"
@@ -51,20 +52,20 @@ namespace drawtypes {
     size_t m_maxlen{0_z};
     bool m_ellipsis{true};
 
-    explicit label(string text, int font) : m_font(font), m_text(text), m_tokenized(m_text) {}
+    explicit label(string text, int font) : m_font(font), m_text(std::move(text)), m_tokenized(m_text) {}
     explicit label(string text, string foreground = ""s, string background = ""s, string underline = ""s,
         string overline = ""s, int font = 0, struct side_values padding = {0U,0U}, struct side_values margin = {0U,0U},
         size_t maxlen = 0_z, bool ellipsis = true, vector<token>&& tokens = {})
-        : m_foreground(foreground)
-        , m_background(background)
-        , m_underline(underline)
-        , m_overline(overline)
+        : m_foreground(std::move(foreground))
+        , m_background(std::move(background))
+        , m_underline(std::move(underline))
+        , m_overline(std::move(overline))
         , m_font(font)
         , m_padding(padding)
         , m_margin(margin)
         , m_maxlen(maxlen)
         , m_ellipsis(ellipsis)
-        , m_text(text)
+        , m_text(std::move(text))
         , m_tokenized(m_text)
         , m_tokens(forward<vector<token>>(tokens)) {
           assert(!m_ellipsis || (m_maxlen == 0 || m_maxlen >= 3));

--- a/include/errors.hpp
+++ b/include/errors.hpp
@@ -14,7 +14,7 @@ using std::runtime_error;
 class application_error : public runtime_error {
  public:
   explicit application_error(const string& message, int code = 0) : runtime_error(message), code(code) {}
-  virtual ~application_error() {}
+  ~application_error() override = default;
   int code{0};
 };
 
@@ -23,7 +23,7 @@ class system_error : public application_error {
   explicit system_error() : application_error(strerror(errno), errno) {}
   explicit system_error(const string& message)
       : application_error(message + " (reason: " + strerror(errno) + ")", errno) {}
-  virtual ~system_error() {}
+  ~system_error() override = default;
 };
 
 #define DEFINE_CHILD_ERROR(error, parent) \

--- a/include/events/signal.hpp
+++ b/include/events/signal.hpp
@@ -20,7 +20,7 @@ namespace signals {
     class signal {
      public:
       explicit signal() = default;
-      virtual ~signal() {}
+      virtual ~signal() = default;
       virtual size_t size() const = 0;
     };
 
@@ -30,9 +30,9 @@ namespace signals {
       using base_type = base_signal<Derived>;
 
       explicit base_signal() = default;
-      virtual ~base_signal() {}
+      ~base_signal() override = default;
 
-      virtual size_t size() const override {
+      size_t size() const override {
         return sizeof(Derived);
       };
     };
@@ -45,7 +45,7 @@ namespace signals {
       explicit value_signal(void* data) : m_ptr(data) {}
       explicit value_signal(ValueType&& data) : m_ptr(&data) {}
 
-      virtual ~value_signal() {}
+      ~value_signal() override = default;
 
       inline ValueType cast() const {
         return *static_cast<ValueType*>(m_ptr);

--- a/include/events/signal_emitter.hpp
+++ b/include/events/signal_emitter.hpp
@@ -21,7 +21,7 @@ class signal_emitter {
   static make_type make();
 
   explicit signal_emitter() = default;
-  virtual ~signal_emitter() {}
+  virtual ~signal_emitter() = default;
 
   template <typename Signal>
   bool emit(const Signal& sig) {

--- a/include/events/signal_receiver.hpp
+++ b/include/events/signal_receiver.hpp
@@ -13,7 +13,7 @@ class signal_receiver_interface {
  public:
   using prio = int;
   using prio_map = std::multimap<prio, signal_receiver_interface*>;
-  virtual ~signal_receiver_interface() {}
+  virtual ~signal_receiver_interface() = default;
   virtual prio priority() const = 0;
   template <typename Signal>
   bool on(const Signal& signal);
@@ -22,7 +22,7 @@ class signal_receiver_interface {
 template <typename Signal>
 class signal_receiver_impl {
  public:
-  virtual ~signal_receiver_impl() {}
+  virtual ~signal_receiver_impl() = default;
   virtual bool on(const Signal&) = 0;
 };
 
@@ -42,7 +42,7 @@ class signal_receiver : public signal_receiver_interface,
                         public signal_receiver_impl<Signal>,
                         public signal_receiver_impl<Signals>... {
  public:
-  prio priority() const {
+  prio priority() const override {
     return Priority;
   }
 };

--- a/include/modules/alsa.hpp
+++ b/include/modules/alsa.hpp
@@ -31,7 +31,7 @@ namespace modules {
     bool build(builder* builder, const string& tag) const;
 
    protected:
-    bool input(string&& cmd);
+    bool input(string&& cmd) override;
 
    private:
     static constexpr auto FORMAT_VOLUME = "format-volume";

--- a/include/modules/battery.hpp
+++ b/include/modules/battery.hpp
@@ -47,7 +47,7 @@ namespace modules {
    public:
     explicit battery_module(const bar_settings&, string);
 
-    void start();
+    void start() override;
     void teardown();
     void idle();
     bool on_event(inotify_event* event);

--- a/include/modules/bspwm.hpp
+++ b/include/modules/bspwm.hpp
@@ -42,14 +42,14 @@ namespace modules {
    public:
     explicit bspwm_module(const bar_settings&, string);
 
-    void stop();
+    void stop() override;
     bool has_event();
     bool update();
     string get_output();
     bool build(builder* builder, const string& tag) const;
 
    protected:
-    bool input(string&& cmd);
+    bool input(string&& cmd) override;
 
    private:
     bool handle_status(string& data);

--- a/include/modules/date.hpp
+++ b/include/modules/date.hpp
@@ -18,7 +18,7 @@ namespace modules {
     bool build(builder* builder, const string& tag) const;
 
    protected:
-    bool input(string&& cmd);
+    bool input(string&& cmd) override;
 
    private:
     static constexpr auto TAG_LABEL = "<label>";

--- a/include/modules/fs.hpp
+++ b/include/modules/fs.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <utility>
+
 #include "components/config.hpp"
 #include "settings.hpp"
 #include "modules/meta/timer_module.hpp"
@@ -25,7 +27,7 @@ namespace modules {
     int percentage_free{0};
     int percentage_used{0};
 
-    explicit fs_mount(const string& mountpoint, bool mounted = false) : mountpoint(mountpoint), mounted(mounted) {}
+    explicit fs_mount(string  mountpoint, bool mounted = false) : mountpoint(std::move(mountpoint)), mounted(mounted) {}
   };
 
   using fs_mount_t = unique_ptr<fs_mount>;

--- a/include/modules/i3.hpp
+++ b/include/modules/i3.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <i3ipc++/ipc.hpp>
+#include <utility>
 
 #include "components/config.hpp"
 #include "modules/meta/event_module.hpp"
@@ -35,7 +36,7 @@ namespace modules {
 
     struct workspace {
       explicit workspace(string name, enum state state_, label_t&& label)
-          : name(name), state(state_), label(forward<label_t>(label)) {}
+          : name(std::move(name)), state(state_), label(forward<label_t>(label)) {}
 
       operator bool();
 
@@ -47,13 +48,13 @@ namespace modules {
    public:
     explicit i3_module(const bar_settings&, string);
 
-    void stop();
+    void stop() override;
     bool has_event();
     bool update();
     bool build(builder* builder, const string& tag) const;
 
    protected:
-    bool input(string&& cmd);
+    bool input(string&& cmd) override;
 
    private:
     static constexpr const char* DEFAULT_TAGS{"<label-state> <label-mode>"};

--- a/include/modules/ipc.hpp
+++ b/include/modules/ipc.hpp
@@ -28,7 +28,7 @@ namespace modules {
    public:
     explicit ipc_module(const bar_settings&, string);
 
-    void start();
+    void start() override;
     void update() {}
     string get_output();
     bool build(builder* builder, const string& tag) const;

--- a/include/modules/menu.hpp
+++ b/include/modules/menu.hpp
@@ -24,7 +24,7 @@ namespace modules {
     void update() {}
 
    protected:
-    bool input(string&& cmd);
+    bool input(string&& cmd) override;
 
    private:
     static constexpr auto TAG_LABEL_TOGGLE = "<label-toggle>";

--- a/include/modules/meta/base.hpp
+++ b/include/modules/meta/base.hpp
@@ -5,6 +5,7 @@
 #include <condition_variable>
 #include <map>
 #include <mutex>
+#include <utility>
 
 #include "common.hpp"
 #include "components/types.hpp"
@@ -84,7 +85,7 @@ namespace modules {
 
   class module_formatter {
    public:
-    explicit module_formatter(const config& conf, string modname) : m_conf(conf), m_modname(modname) {}
+    explicit module_formatter(const config& conf, string modname) : m_conf(conf), m_modname(std::move(modname)) {}
 
     void add(string name, string fallback, vector<string>&& tags, vector<string>&& whitelist = {});
     bool has(const string& tag, const string& format_name);
@@ -103,7 +104,7 @@ namespace modules {
 
   struct module_interface {
    public:
-    virtual ~module_interface() {}
+    virtual ~module_interface() = default;
 
     virtual string name() const = 0;
     virtual bool running() const = 0;
@@ -121,14 +122,14 @@ namespace modules {
   class module : public module_interface {
    public:
     module(const bar_settings bar, string name);
-    ~module() noexcept;
+    ~module() noexcept override;
 
-    string name() const;
-    bool running() const;
-    void stop();
-    void halt(string error_message);
+    string name() const override;
+    bool running() const override;
+    void stop() override;
+    void halt(string error_message) override;
     void teardown();
-    string contents();
+    string contents() override;
 
    protected:
     void broadcast();

--- a/include/modules/meta/event_handler.hpp
+++ b/include/modules/meta/event_handler.hpp
@@ -10,7 +10,7 @@ class connection;
 
 namespace modules {
   struct event_handler_interface {
-    virtual ~event_handler_interface() {}
+    virtual ~event_handler_interface() = default;
     virtual void connect(connection&) {}
     virtual void disconnect(connection&) {}
   };
@@ -18,13 +18,13 @@ namespace modules {
   template <typename Event, typename... Events>
   class event_handler : public event_handler_interface, public xpp::event::sink<Event, Events...> {
    public:
-    virtual ~event_handler() {}
+    ~event_handler() override = default;
 
-    virtual void connect(connection& conn) override {
+    void connect(connection& conn) override {
       conn.attach_sink(this, SINK_PRIORITY_MODULE);
     }
 
-    virtual void disconnect(connection& conn) override {
+    void disconnect(connection& conn) override {
       conn.detach_sink(this, SINK_PRIORITY_MODULE);
     }
   };

--- a/include/modules/meta/input_handler.hpp
+++ b/include/modules/meta/input_handler.hpp
@@ -7,7 +7,7 @@ POLYBAR_NS
 namespace modules {
   class input_handler {
    public:
-    virtual ~input_handler() {}
+    virtual ~input_handler() = default;
     virtual bool input(string&& cmd) = 0;
   };
 }

--- a/include/modules/pulseaudio.hpp
+++ b/include/modules/pulseaudio.hpp
@@ -24,7 +24,7 @@ namespace modules {
     bool build(builder* builder, const string& tag) const;
 
    protected:
-    bool input(string&& cmd);
+    bool input(string&& cmd) override;
 
    private:
     static constexpr auto FORMAT_VOLUME = "format-volume";

--- a/include/modules/script.hpp
+++ b/include/modules/script.hpp
@@ -10,10 +10,10 @@ namespace modules {
   class script_module : public module<script_module> {
    public:
     explicit script_module(const bar_settings&, string);
-    ~script_module() {}
+    ~script_module() override = default;
 
-    void start();
-    void stop();
+    void start() override;
+    void stop() override;
 
     string get_output();
     bool build(builder* builder, const string& tag) const;

--- a/include/modules/xbacklight.hpp
+++ b/include/modules/xbacklight.hpp
@@ -36,8 +36,8 @@ namespace modules {
     bool build(builder* builder, const string& tag) const;
 
    protected:
-    void handle(const evt::randr_notify& evt);
-    bool input(string&& cmd);
+    void handle(const evt::randr_notify& evt) override;
+    bool input(string&& cmd) override;
 
    private:
     static constexpr const char* TAG_LABEL{"<label>"};

--- a/include/modules/xkeyboard.hpp
+++ b/include/modules/xkeyboard.hpp
@@ -32,11 +32,11 @@ namespace modules {
     bool query_keyboard();
     bool blacklisted(const string& indicator_name);
 
-    void handle(const evt::xkb_new_keyboard_notify& evt);
-    void handle(const evt::xkb_state_notify& evt);
-    void handle(const evt::xkb_indicator_state_notify& evt);
+    void handle(const evt::xkb_new_keyboard_notify& evt) override;
+    void handle(const evt::xkb_state_notify& evt) override;
+    void handle(const evt::xkb_indicator_state_notify& evt) override;
 
-    bool input(string&& cmd);
+    bool input(string&& cmd) override;
 
    private:
     static constexpr const char* TAG_LABEL_LAYOUT{"<label-layout>"};

--- a/include/modules/xwindow.hpp
+++ b/include/modules/xwindow.hpp
@@ -41,7 +41,7 @@ namespace modules {
     bool build(builder* builder, const string& tag) const;
 
    protected:
-    void handle(const evt::property_notify& evt);
+    void handle(const evt::property_notify& evt) override;
 
    private:
     static constexpr const char* TAG_LABEL{"<label>"};

--- a/include/modules/xworkspaces.hpp
+++ b/include/modules/xworkspaces.hpp
@@ -61,14 +61,14 @@ namespace modules {
     bool build(builder* builder, const string& tag) const;
 
    protected:
-    void handle(const evt::property_notify& evt);
+    void handle(const evt::property_notify& evt) override;
 
     void rebuild_clientlist();
     void rebuild_desktops();
     void rebuild_desktop_states();
     void set_desktop_urgent(xcb_window_t window);
 
-    bool input(string&& cmd);
+    bool input(string&& cmd) override;
     vector<string> get_desktop_names();
 
    private:

--- a/include/utils/file.hpp
+++ b/include/utils/file.hpp
@@ -58,7 +58,7 @@ class fd_streambuf : public std::streambuf {
     setg(m_in, m_in, m_in);
     setp(m_out, m_out + bufsize - 1);
   }
-  ~fd_streambuf();
+  ~fd_streambuf() override;
 
   explicit operator int();
   operator int() const;
@@ -67,9 +67,9 @@ class fd_streambuf : public std::streambuf {
   void close();
 
  protected:
-  int sync();
-  int overflow(int c);
-  int underflow();
+  int sync() override;
+  int overflow(int c) override;
+  int underflow() override;
 
  private:
   file_descriptor m_fd;

--- a/include/utils/mixins.hpp
+++ b/include/utils/mixins.hpp
@@ -10,12 +10,12 @@ POLYBAR_NS
 template <class T>
 class non_copyable_mixin {
  protected:
-  non_copyable_mixin() {}
-  ~non_copyable_mixin() {}
+  non_copyable_mixin() = default;
+  ~non_copyable_mixin() = default;
 
  private:
-  non_copyable_mixin(const non_copyable_mixin&);
-  non_copyable_mixin& operator=(const non_copyable_mixin&);
+  non_copyable_mixin(const non_copyable_mixin&) = delete;
+  non_copyable_mixin& operator=(const non_copyable_mixin&) = delete;
 };
 
 /**
@@ -24,12 +24,12 @@ class non_copyable_mixin {
 template <class T>
 class non_movable_mixin {
  protected:
-  non_movable_mixin() {}
-  ~non_movable_mixin() {}
+  non_movable_mixin() = default;
+  ~non_movable_mixin() = default;
 
  private:
-  non_movable_mixin(non_movable_mixin&&);
-  non_movable_mixin& operator=(non_movable_mixin&&);
+  non_movable_mixin(non_movable_mixin&&) = delete;
+  non_movable_mixin& operator=(non_movable_mixin&&) = delete;
 };
 
 POLYBAR_NS_END

--- a/include/x11/background_manager.hpp
+++ b/include/x11/background_manager.hpp
@@ -77,7 +77,7 @@ class background_manager : public signal_receiver<SIGN_PRIORITY_SCREEN, signals:
    * To observe a slice of the background you need to call background_manager::activate.
    */
   explicit background_manager(connection& conn, signal_emitter& sig, const logger& log);
-  ~background_manager();
+  ~background_manager() override;
 
   /**
    * Starts observing a rectangular slice of the desktop background.
@@ -96,8 +96,8 @@ class background_manager : public signal_receiver<SIGN_PRIORITY_SCREEN, signals:
    */
   std::shared_ptr<bg_slice> observe(xcb_rectangle_t rect, xcb_window_t window);
 
-  void handle(const evt::property_notify& evt);
-  bool on(const signals::ui::update_geometry&);
+  void handle(const evt::property_notify& evt) override;
+  bool on(const signals::ui::update_geometry&) override;
  private:
   void activate();
   void deactivate();

--- a/include/x11/connection.hpp
+++ b/include/x11/connection.hpp
@@ -42,9 +42,9 @@ namespace detail {
       m_root_window = screen_of_display(default_screen())->root;
     }
 
-    virtual ~connection_base() {}
+    ~connection_base() override = default;
 
-    void operator()(const shared_ptr<xcb_generic_error_t>& error) const {
+    void operator()(const shared_ptr<xcb_generic_error_t>& error) const override {
       check<xpp::x::extension, Extensions...>(error);
     }
 
@@ -59,7 +59,7 @@ namespace detail {
       return make()(*this, m_root_window);
     }
 
-    shared_ptr<xcb_generic_event_t> wait_for_event() const {
+    shared_ptr<xcb_generic_event_t> wait_for_event() const override {
       try {
         return core::wait_for_event();
       } catch (const shared_ptr<xcb_generic_error_t>& error) {
@@ -68,7 +68,7 @@ namespace detail {
       throw;  // re-throw exception
     }
 
-    shared_ptr<xcb_generic_event_t> wait_for_special_event(xcb_special_event_t* se) const {
+    shared_ptr<xcb_generic_event_t> wait_for_special_event(xcb_special_event_t* se) const override {
       try {
         return core::wait_for_special_event(se);
       } catch (const shared_ptr<xcb_generic_error_t>& error) {
@@ -103,7 +103,7 @@ class connection : public detail::connection_base<connection&, XPP_EXTENSION_LIS
   static make_type make(xcb_connection_t* conn = nullptr, int default_screen = 0);
 
   explicit connection(xcb_connection_t* c, int default_screen);
-  ~connection();
+  ~connection() override;
 
   const connection& operator=(const connection& o) {
     return o;

--- a/include/x11/tray_manager.hpp
+++ b/include/x11/tray_manager.hpp
@@ -75,7 +75,7 @@ class tray_manager
 
   explicit tray_manager(connection& conn, signal_emitter& emitter, const logger& logger, background_manager& back);
 
-  ~tray_manager();
+  ~tray_manager() override;
 
   const tray_settings settings() const;
 
@@ -120,21 +120,21 @@ class tray_manager
   void remove_client(xcb_window_t win, bool reconfigure = true);
   unsigned int mapped_clients() const;
 
-  void handle(const evt::expose& evt);
-  void handle(const evt::visibility_notify& evt);
-  void handle(const evt::client_message& evt);
-  void handle(const evt::configure_request& evt);
-  void handle(const evt::resize_request& evt);
-  void handle(const evt::selection_clear& evt);
-  void handle(const evt::property_notify& evt);
-  void handle(const evt::reparent_notify& evt);
-  void handle(const evt::destroy_notify& evt);
-  void handle(const evt::map_notify& evt);
-  void handle(const evt::unmap_notify& evt);
+  void handle(const evt::expose& evt) override;
+  void handle(const evt::visibility_notify& evt) override;
+  void handle(const evt::client_message& evt) override;
+  void handle(const evt::configure_request& evt) override;
+  void handle(const evt::resize_request& evt) override;
+  void handle(const evt::selection_clear& evt) override;
+  void handle(const evt::property_notify& evt) override;
+  void handle(const evt::reparent_notify& evt) override;
+  void handle(const evt::destroy_notify& evt) override;
+  void handle(const evt::map_notify& evt) override;
+  void handle(const evt::unmap_notify& evt) override;
 
-  bool on(const signals::ui::visibility_change& evt);
-  bool on(const signals::ui::dim_window& evt);
-  bool on(const signals::ui::update_background& evt);
+  bool on(const signals::ui::visibility_change& evt) override;
+  bool on(const signals::ui::dim_window& evt) override;
+  bool on(const signals::ui::update_background& evt) override;
 
  private:
   connection& m_connection;

--- a/src/adapters/pulseaudio.cpp
+++ b/src/adapters/pulseaudio.cpp
@@ -227,7 +227,7 @@ void pulseaudio::update_volume(pa_operation *o) {
  * Callback when getting volume
  */
 void pulseaudio::get_sink_volume_callback(pa_context *, const pa_sink_info *info, int, void *userdata) {
-  pulseaudio* This = static_cast<pulseaudio *>(userdata);
+  auto* This = static_cast<pulseaudio *>(userdata);
   if (info) {
     This->cv = info->volume;
     This->muted = info->mute;
@@ -239,7 +239,7 @@ void pulseaudio::get_sink_volume_callback(pa_context *, const pa_sink_info *info
  * Callback when subscribing to changes
  */
 void pulseaudio::subscribe_callback(pa_context *, pa_subscription_event_type_t t, uint32_t idx, void* userdata) {
-  pulseaudio *This = static_cast<pulseaudio *>(userdata);
+  auto *This = static_cast<pulseaudio *>(userdata);
   switch(t & PA_SUBSCRIPTION_EVENT_FACILITY_MASK) {
     case PA_SUBSCRIPTION_EVENT_SERVER:
       switch(t & PA_SUBSCRIPTION_EVENT_TYPE_MASK) {
@@ -271,7 +271,7 @@ void pulseaudio::subscribe_callback(pa_context *, pa_subscription_event_type_t t
  * Simple callback to check for success
  */
 void pulseaudio::simple_callback(pa_context *, int success, void *userdata) {
-  pulseaudio *This = static_cast<pulseaudio *>(userdata);
+  auto *This = static_cast<pulseaudio *>(userdata);
   This->success = success;
   pa_threaded_mainloop_signal(This->m_mainloop, 0);
 }
@@ -281,7 +281,7 @@ void pulseaudio::simple_callback(pa_context *, int success, void *userdata) {
  * Callback when getting sink info & existence
  */
 void pulseaudio::sink_info_callback(pa_context *, const pa_sink_info *info, int eol, void *userdata) {
-  pulseaudio *This = static_cast<pulseaudio *>(userdata);
+  auto *This = static_cast<pulseaudio *>(userdata);
   if (!eol && info) {
     This->m_index = info->index;
     This->s_name = info->name;
@@ -293,7 +293,7 @@ void pulseaudio::sink_info_callback(pa_context *, const pa_sink_info *info, int 
  * Callback when context state changes
  */
 void pulseaudio::context_state_callback(pa_context *context, void *userdata) {
-  pulseaudio* This = static_cast<pulseaudio *>(userdata);
+  auto* This = static_cast<pulseaudio *>(userdata);
   switch (pa_context_get_state(context)) {
     case PA_CONTEXT_READY:
     case PA_CONTEXT_TERMINATED:

--- a/src/components/bar.cpp
+++ b/src/components/bar.cpp
@@ -116,7 +116,7 @@ bar::bar(connection& conn, signal_emitter& emitter, const config& config, const 
   if (!m_opts.monitor) {
     if (fallback) {
       m_opts.monitor = move(fallback);
-      m_log.warn("Monitor \"%s\" not found, reverting to fallback \"%s\"", monitor_name, m_opts.monitor->name);
+      m_log.warn(R"(Monitor "%s" not found, reverting to fallback "%s")", monitor_name, m_opts.monitor->name);
     } else {
       throw application_error("Monitor \"" + monitor_name + "\" not found or disconnected");
     }

--- a/src/components/config.cpp
+++ b/src/components/config.cpp
@@ -1,5 +1,6 @@
 #include <climits>
 #include <fstream>
+#include <memory>
 
 #include "cairo/utils.hpp"
 #include "components/config.hpp"
@@ -166,7 +167,7 @@ void config::parse_file() {
     // Initialize the xresource manage if there are any xrdb refs
     // present in the configuration
     if (!m_xrm && value.find("${xrdb") != string::npos) {
-      m_xrm.reset(new xresource_manager{connection::make()});
+      m_xrm = std::make_unique<xresource_manager>(connection::make());
     }
 #endif
 
@@ -188,7 +189,7 @@ void config::copy_inherited() {
         // Get name of base section
         auto inherit = param.second;
         if ((inherit = dereference<string>(section.first, param.first, inherit, inherit)).empty()) {
-          throw value_error("Invalid section \"\" defined for \"" + section.first + ".inherit\"");
+          throw value_error(R"(Invalid section "" defined for ")" + section.first + ".inherit\"");
         }
 
         // Find and validate base section
@@ -197,7 +198,7 @@ void config::copy_inherited() {
           throw value_error("Invalid section \"" + inherit + "\" defined for \"" + section.first + ".inherit\"");
         }
 
-        m_log.trace("config: Copying missing params (sub=\"%s\", base=\"%s\")", section.first, inherit);
+        m_log.trace(R"(config: Copying missing params (sub="%s", base="%s"))", section.first, inherit);
 
         // Iterate the base and copy the parameters
         // that hasn't been defined for the sub-section

--- a/src/modules/xworkspaces.cpp
+++ b/src/modules/xworkspaces.cpp
@@ -170,11 +170,11 @@ namespace modules {
       step = 1;
     }
     unsigned int offset = 0;
-    for (unsigned int i = 0; i < bounds.size(); i++) {
-      if (!m_pinworkspaces || m_bar.monitor->match(bounds[i])) {
+    for (auto bound : bounds) {
+      if (!m_pinworkspaces || m_bar.monitor->match(bound)) {
         auto viewport = make_unique<struct viewport>();
         viewport->state = viewport_state::UNFOCUSED;
-        viewport->pos = bounds[i];
+        viewport->pos = bound;
 
         for (auto&& m : m_monitors) {
           if (m->match(viewport->pos)) {

--- a/src/x11/icccm.cpp
+++ b/src/x11/icccm.cpp
@@ -32,7 +32,7 @@ namespace icccm_util {
 
   bool get_wm_urgency(xcb_connection_t* c, xcb_window_t w) {
     xcb_icccm_wm_hints_t hints;
-    if (xcb_icccm_get_wm_hints_reply(c, xcb_icccm_get_wm_hints(c, w), &hints, NULL)) {
+    if (xcb_icccm_get_wm_hints_reply(c, xcb_icccm_get_wm_hints(c, w), &hints, nullptr)) {
       if(xcb_icccm_wm_hints_get_urgency(&hints) == XCB_ICCCM_WM_HINT_X_URGENCY)
         return true;
     }


### PR DESCRIPTION
Hey,
I quickly applied clang-tidy modernize-* fixes with clang-tidy 7.0. It would be nice to also call clang-format but there were multiple changes that would obfuscate the PR.