### PR TITLE
Improve temperature ramp configuration

### DIFF
--- a/include/modules/temperature.hpp
+++ b/include/modules/temperature.hpp
@@ -29,9 +29,11 @@ namespace modules {
 
     string m_path;
     int m_zone = 0;
+    // Base temperature used for where to start the ramp
     int m_tempbase = 0;
     int m_tempwarn = 0;
     int m_temp = 0;
+    // Percentage used in the ramp
     int m_perc = 0;
 
     // Whether or not to show units with the %temperature-X% tokens

--- a/include/modules/temperature.hpp
+++ b/include/modules/temperature.hpp
@@ -29,6 +29,7 @@ namespace modules {
 
     string m_path;
     int m_zone = 0;
+    int m_tempbase = 0;
     int m_tempwarn = 0;
     int m_temp = 0;
     int m_perc = 0;

--- a/src/modules/temperature.cpp
+++ b/src/modules/temperature.cpp
@@ -17,6 +17,7 @@ namespace modules {
       : timer_module<temperature_module>(bar, move(name_)) {
     m_zone = m_conf.get(name(), "thermal-zone", 0);
     m_path = m_conf.get(name(), "hwmon-path", ""s);
+    m_tempbase = m_conf.get(name(), "base-temperature", 0);
     m_tempwarn = m_conf.get(name(), "warn-temperature", 80);
     m_interval = m_conf.get<decltype(m_interval)>(name(), "interval", 1s);
     m_units = m_conf.get(name(), "units", m_units);
@@ -52,7 +53,7 @@ namespace modules {
   bool temperature_module::update() {
     m_temp = std::strtol(file_util::contents(m_path).c_str(), nullptr, 10) / 1000.0f + 0.5f;
     int temp_f = floor(((1.8 * m_temp) + 32) + 0.5);
-    m_perc = math_util::cap(math_util::percentage(m_temp, 0, m_tempwarn), 0, 100);
+    m_perc = math_util::cap(math_util::percentage(m_temp, m_tempbase, m_tempwarn), 0, 100);
 
     string temp_c_string = to_string(m_temp);
     string temp_f_string = to_string(temp_f);


### PR DESCRIPTION
add configuration `base_temperature` to make it easy to set ramp icons.

resolves #1703

TEAM EDIT: Documentation:

```dosini
; Base temperature for where to start the ramp (in degrees celsius)
; Default: 0
base-temperature = 20

; Requires the <ramp> tag
; The icon selection will range from `base-temperature` to `warn-temperature`,
; temperatures above `warn-temperature` will use the last icon
; and temperatures below `base-temperature` will use `ramp-0`
ramp-0 = A
ramp-1 = B
ramp-2 = C
ramp-foreground = #55
```