### PR TITLE
CMake improvement (moving generated sources out of sources directories)

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -35,8 +35,9 @@ endif()
 
 configure_file(
   ${CMAKE_CURRENT_LIST_DIR}/settings.hpp.cmake
-  ${CMAKE_CURRENT_LIST_DIR}/settings.hpp
+  ${CMAKE_BINARY_DIR}/generated-sources/settings.hpp
   ESCAPE_QUOTES @ONLY)
 
+list(APPEND dirs ${CMAKE_BINARY_DIR}/generated-sources/)
 set(APP_VERSION ${APP_VERSION} PARENT_SCOPE)
 set(dirs ${dirs} PARENT_SCOPE)


### PR DESCRIPTION
This PR is a proposition to move auto-generated files in build directory.
The problem with generating sources in sources directories is that it may cause problem when the compilation mode (Release; Debug; …) is changed without cleaning.

Furthermore, some IDEs that support CMake create a build directory per compilation mode, so the project directory has the following architecture:
```
|─ debug-build/
|─ release-build/
|─ include/
     |─ setting.hpp
     |─ setting.hpp.cmake
```

With generated sources in the sources directories when I change from Debug to Release, cmake doesn't regenerate the setting file since it already exists but if you move the generated files in the build directory the problem disappears.

```
|─ debug-build/
     |─ generated-sources/
          |─ setting.hpp
|─ release-build/
     |─ generated-sources/
          |─ setting.hpp
|─ include/
     |─ setting.hpp.cmake
```