### PR TITLE
Fix compilation under gcc 9

### DIFF
--- a/include/x11/window.hpp
+++ b/include/x11/window.hpp
@@ -12,9 +12,8 @@ class connection;
 
 class window : public xpp::window<connection&> {
  public:
+  window(const window&) = default;
   using xpp::window<class connection&>::window;
-
-  window& operator=(const xcb_window_t win);
 
   window reconfigure_geom(unsigned short int w, unsigned short int h, short int x = 0, short int y = 0);
   window reconfigure_pos(short int x, short int y);

--- a/src/x11/window.cpp
+++ b/src/x11/window.cpp
@@ -7,11 +7,6 @@
 
 POLYBAR_NS
 
-window& window::operator=(const xcb_window_t win) {
-  resource(connection(), win);
-  return *this;
-}
-
 /**
  * Reconfigure the window geometry
  */


### PR DESCRIPTION
Fixes #1728.
Add default copy constructor whose implicit generation is deprecated by C++ standard.

I also remove the `window& operator=(const xcb_window_t win);` operator that seems to be useless.
https://github.com/jaagr/polybar/blob/7d0c6300f6d63eb018b842d122b98fb7c4efbaef/src/x11/window.cpp#L10-L13
If I am not wrong this `operator=` constructs an `resource` object which is destroyed immediately so this is useless.

This PR also depend on a PR on xpp (https://github.com/jaagr/xpp/pull/16)