### PR TITLE
build: Add build type specific flags to -vvv

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -27,7 +27,7 @@ string(REPLACE ";" ", " XPP_EXTENSION_LIST "${XPP_EXTENSION_LIST}")
 configure_file(
   ${CMAKE_CURRENT_LIST_DIR}/settings.hpp.cmake
   ${CMAKE_BINARY_DIR}/generated-sources/settings.hpp
-  ESCAPE_QUOTES @ONLY)
+  ESCAPE_QUOTES)
 
 list(APPEND dirs ${CMAKE_BINARY_DIR}/generated-sources/)
 set(APP_VERSION ${APP_VERSION} PARENT_SCOPE)

--- a/include/settings.hpp.cmake
+++ b/include/settings.hpp.cmake
@@ -118,8 +118,8 @@ const auto print_build_info = [](bool extended = false) {
     printf("\n");
     printf("Build type: @CMAKE_BUILD_TYPE@\n");
     printf("Compiler: @CMAKE_CXX_COMPILER@\n");
-    printf("Compiler flags: @CMAKE_CXX_FLAGS@\n");
-    printf("Linker flags: @CMAKE_EXE_LINKER_FLAGS@\n");
+    printf("Compiler flags: @CMAKE_CXX_FLAGS@ ${CMAKE_CXX_FLAGS_${CMAKE_BUILD_TYPE_UPPER}}\n");
+    printf("Linker flags: @CMAKE_EXE_LINKER_FLAGS@ ${CMAKE_EXE_LINKER_FLAGS_${CMAKE_BUILD_TYPE_UPPER}}\n");
   }
 };
 // clang-format on


### PR DESCRIPTION
Bothered me for quite some time that `polybar -vvv` doesn't actually print the effective flags used